### PR TITLE
Fix build of priority benchmark

### DIFF
--- a/http2.cabal
+++ b/http2.cabal
@@ -284,6 +284,7 @@ Benchmark priority
                       , hashtables
                       , heaps
                       , mwc-random
+                      , random
                       , psqueues
                       , stm
 


### PR DESCRIPTION
```
bench-priority/Main.hs:8:1: error:
    Failed to load interface for ‘System.Random’
    It is a member of the hidden package ‘random-1.1’.
    Perhaps you need to add ‘random’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```