### PR TITLE
Return correct status messages in HTTP2 client

### DIFF
--- a/Network/HTTP2/Arch/Status.hs
+++ b/Network/HTTP2/Arch/Status.hs
@@ -41,4 +41,4 @@ fromStatus status = unsafeCreate 3 $ \p -> do
 toStatus :: ByteString -> Maybe H.Status
 toStatus bs = case C8.readInt bs of
   Nothing       -> Nothing
-  Just (code,_) -> Just $ H.mkStatus code "fixme"
+  Just (code,_) -> Just $ toEnum code

--- a/test/HTTP2/ServerSpec.hs
+++ b/test/HTTP2/ServerSpec.hs
@@ -116,6 +116,7 @@ client0 sendRequest = do
     let req = C.requestNoBody methodGet "/" []
     sendRequest req $ \rsp -> do
         C.responseStatus rsp `shouldBe` Just ok200
+        fmap statusMessage (C.responseStatus rsp) `shouldBe` Just "OK"
 
 client1 :: C.Client ()
 client1 sendRequest = do


### PR DESCRIPTION
The `Enum` instance of `Status` can be used to create values containing the usual values for the message. This replaces the hardcoded "fixme" value that was previously returned as part of the status.