### PR TITLE
Follow changes in Aeson 2

### DIFF
--- a/http2.cabal
+++ b/http2.cabal
@@ -206,7 +206,7 @@ Test-Suite hpack
                         HPACKSpec
                         JSON
   Build-Depends:        base >= 4.9 && < 5
-                      , aeson
+                      , aeson >= 2
                       , base16-bytestring >= 1.0
                       , bytestring
                       , directory
@@ -230,7 +230,7 @@ Test-Suite frame
                         JSON
   Build-Depends:        base >= 4.9 && < 5
                       , Glob >= 0.9
-                      , aeson
+                      , aeson >= 2
                       , aeson-pretty
                       , base16-bytestring >= 1.0
                       , bytestring
@@ -293,7 +293,7 @@ Executable hpack-encode
   Other-Modules:        HPACKEncode
                         JSON
   Build-Depends:        base >= 4.9 && < 5
-                      , aeson
+                      , aeson >= 2
                       , aeson-pretty
                       , array
                       , base16-bytestring >= 1.0
@@ -320,7 +320,7 @@ Executable hpack-debug
   Other-Modules:        HPACKDecode
                         JSON
   Build-Depends:        base >= 4.9 && < 5
-                      , aeson
+                      , aeson >= 2
                       , array
                       , base16-bytestring >= 1.0
                       , bytestring
@@ -345,7 +345,7 @@ Executable hpack-stat
   Main-Is:              hpack-stat.hs
   Other-Modules:        JSON
   Build-Depends:        base >= 4.9 && < 5
-                      , aeson
+                      , aeson >= 2
                       , aeson-pretty
                       , array
                       , bytestring
@@ -373,7 +373,7 @@ Executable frame-encode
   Other-Modules:        Case
                         JSON
   Build-Depends:        base >= 4.9 && < 5
-                      , aeson
+                      , aeson >= 2
                       , aeson-pretty
                       , base16-bytestring >= 1.0
                       , bytestring

--- a/test-frame/JSON.hs
+++ b/test-frame/JSON.hs
@@ -14,7 +14,7 @@ import Data.Aeson.Types
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
-import Data.HashMap.Strict (union)
+import Data.Aeson.KeyMap (union)
 import Data.Maybe (fromJust)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/test-hpack/JSON.hs
+++ b/test-hpack/JSON.hs
@@ -14,7 +14,8 @@ import Control.Monad (mzero)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
-import qualified Data.HashMap.Strict as H
+import qualified Data.Aeson.KeyMap as H
+import qualified Data.Aeson.Key as Key
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Vector ((!))
@@ -83,13 +84,13 @@ instance {-# OVERLAPPING #-} FromJSON Header where
     parseJSON (Array a)  = pure (toKey (a ! 0), toValue (a ! 1)) -- old
       where
         toKey = toValue
-    parseJSON (Object o) = pure (textToByteString k, toValue v) -- new
+    parseJSON (Object o) = pure (textToByteString (Key.toText k), toValue v) -- new
       where
         (k,v) = head $ H.toList o
     parseJSON _          = mzero
 
 instance {-# OVERLAPPING #-} ToJSON Header where
-    toJSON (k,v) = object [ byteStringToText k .= byteStringToText v ]
+    toJSON (k,v) = object [ Key.fromText (byteStringToText k) .= byteStringToText v ]
 
 textToByteString :: Text -> ByteString
 textToByteString = B8.pack . T.unpack


### PR DESCRIPTION
This makes http2 tests compile with aeson 2 and sets minimum version bounds accordingly.