### PR TITLE
Make sure connection preface is always sent first

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -24,11 +24,11 @@ run ClientConfig{..} conf@Config{..} client = do
     clientInfo <- newClientInfo scheme authority cacheLimit
     ctx <- newContext clientInfo
     mgr <- start confTimeoutManager
+    exchangeSettings conf ctx
     tid0 <- forkIO $ frameReceiver ctx confReadN
     -- fixme: if frameSender is terminated but the main thread is alive,
     --        what will happen?
     tid1 <- forkIO $ frameSender ctx conf mgr
-    exchangeSettings conf ctx
     client (sendRequest ctx scheme authority) `E.finally` do
         stop mgr
         killThread tid0

--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -3,6 +3,7 @@
 
 module Network.HTTP2.Client.Run where
 
+import Control.Concurrent.Async
 import Control.Concurrent
 import qualified Control.Exception as E
 import Data.IORef (writeIORef)
@@ -24,15 +25,15 @@ run ClientConfig{..} conf@Config{..} client = do
     clientInfo <- newClientInfo scheme authority cacheLimit
     ctx <- newContext clientInfo
     mgr <- start confTimeoutManager
+    let runBackgroundThreads = do
+            race_
+                (frameReceiver ctx confReadN)
+                (frameSender ctx conf mgr)
+            E.throwIO (ConnectionError ProtocolError "connection terminated")
     exchangeSettings conf ctx
-    tid0 <- forkIO $ frameReceiver ctx confReadN
-    -- fixme: if frameSender is terminated but the main thread is alive,
-    --        what will happen?
-    tid1 <- forkIO $ frameSender ctx conf mgr
-    client (sendRequest ctx scheme authority) `E.finally` do
-        stop mgr
-        killThread tid0
-        killThread tid1
+    fmap (either id id) $
+        race runBackgroundThreads (client (sendRequest ctx scheme authority))
+            `E.finally` stop mgr
 
 sendRequest :: Context -> Scheme -> Authority -> Request -> (Response -> IO a) -> IO a
 sendRequest ctx@Context{..} scheme auth (Request req) processResponse = do

--- a/http2.cabal
+++ b/http2.cabal
@@ -119,6 +119,7 @@ Library
                         Network.HTTP2.Server.Worker
   Build-Depends:        base >= 4.9 && < 5
                       , array
+                      , async
                       , bytestring >= 0.10
                       , case-insensitive
                       , containers >= 0.5

--- a/http2.cabal
+++ b/http2.cabal
@@ -169,6 +169,7 @@ Test-Suite spec
                       , hspec >= 1.3
                       , http-types
                       , http2
+                      , network
                       , network-run >= 0.1.0
                       , typed-process
   Default-Extensions:   Strict StrictData


### PR DESCRIPTION
This fixes a race condition in the client between the `frameSender` thread and the main thread, in the case where a SETTINGS frame is sent in response to a server SETTINGS frame before the connection preface has had a chance to be sent.

This PR also includes a commit to prevent client threads from waiting forever on stream input when the client `frameSender` thread dies. This is useful in its own right, I think, but in particular it is needed to make the test for the above fix work. 