### PR TITLE
Remove leftover `promiseWeight` haddock

### DIFF
--- a/Network/HTTP2/Server/Types.hs
+++ b/Network/HTTP2/Server/Types.hs
@@ -29,7 +29,6 @@ data PushPromise = PushPromise {
       promiseRequestPath :: ByteString
     -- | Accessor for response actually pushed from a server.
     , promiseResponse    :: Response
-    -- | Accessor for response weight.
     }
 
 -- | Additional information.


### PR DESCRIPTION
The `promiseWeight` field was removed as part of b88a4be7 while its haddock was not removed.

Closes #42