### PR TITLE
Implementing streaming flush

### DIFF
--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -182,7 +182,9 @@ type DynaNext = Buffer -> BufferSize -> WindowSize -> IO Next
 
 type BytesFilled = Int
 
-data Next = Next BytesFilled (Maybe DynaNext)
+data Next = Next BytesFilled      -- payload length
+                 Bool             -- require flushing
+                 (Maybe DynaNext)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
@epoberezkin  This should fix #46.

This code call `writev(2)` or something for flusing. It is up to the TCP layer how TCP packets are organized.