### PR TITLE
docs (ChangeLog): fix link markup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,13 +2,13 @@
 
 * Removing the race of frameSender and frameReceiver in the server side.
   This fixes the loss of RST_Stream and TLS bad MAC error.
-  [#67][https://github.com/kazu-yamamoto/http2/pull/67]
+  [#67](https://github.com/kazu-yamamoto/http2/pull/67)
 
 ## 4.1.1
 
 * Fixing memory-blow-up due to no flow control.
-  [#62][https://github.com/kazu-yamamoto/http2/issues/62]
-  [#66][https://github.com/kazu-yamamoto/http2/issues/66]
+  [#62](https://github.com/kazu-yamamoto/http2/issues/62)
+  [#66](https://github.com/kazu-yamamoto/http2/issues/66)
 
 ## 4.1.0
 


### PR DESCRIPTION
(Just a quick drive-by change: see diff.)