### PR TITLE
debugging flow control

### DIFF
--- a/Imports.hs
+++ b/Imports.hs
@@ -8,10 +8,11 @@ module Imports (
   , module Data.List
   , module Data.Foldable
   , module Data.Int
+  , module Data.Maybe
   , module Data.Monoid
   , module Data.Ord
+  , module Data.String
   , module Data.Word
-  , module Data.Maybe
   , module Numeric
   , GCBuffer
   , withForeignPtr
@@ -29,6 +30,7 @@ import Data.Int
 import Data.List
 import Data.Maybe
 import Data.Monoid
+import Data.String
 import Data.Ord
 import Data.Word
 import Foreign.ForeignPtr

--- a/Network/HTTP2/Arch/HPACK.hs
+++ b/Network/HTTP2/Arch/HPACK.hs
@@ -69,15 +69,16 @@ hpackDecodeHeader hdrblk sid ctx = do
     if isClient ctx || checkRequestHeader vt then
         return tbl
       else
-        E.throwIO $ StreamErrorIsSent ProtocolError sid
+        E.throwIO $ StreamErrorIsSent ProtocolError sid "illegal header"
 
 hpackDecodeTrailer :: HeaderBlockFragment -> StreamId -> Context -> IO HeaderTable
 hpackDecodeTrailer hdrblk sid Context{..} = decodeTokenHeader decodeDynamicTable hdrblk `E.catch` handl
   where
     handl IllegalHeaderName =
-        E.throwIO $ StreamErrorIsSent ProtocolError sid
-    handl _ =
-        E.throwIO $ StreamErrorIsSent CompressionError sid
+        E.throwIO $ StreamErrorIsSent ProtocolError sid "illegal trailer"
+    handl e = do
+        let msg = fromString $ show e
+        E.throwIO $ StreamErrorIsSent CompressionError sid msg
 
 {-# INLINE checkRequestHeader #-}
 checkRequestHeader :: ValueTable -> Bool

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -212,7 +212,7 @@ data HTTP2Error =
   | ConnectionErrorIsReceived ErrorCode StreamId ReasonPhrase
   | ConnectionErrorIsSent     ErrorCode StreamId ReasonPhrase
   | StreamErrorIsReceived     ErrorCode StreamId
-  | StreamErrorIsSent         ErrorCode StreamId
+  | StreamErrorIsSent         ErrorCode StreamId ReasonPhrase
   | BadThingHappen E.SomeException
   deriving (Show, Typeable)
 

--- a/Network/HTTP2/Arch/Window.hs
+++ b/Network/HTTP2/Arch/Window.hs
@@ -4,6 +4,7 @@
 module Network.HTTP2.Arch.Window where
 
 import Data.IORef
+import qualified UnliftIO.Exception as E
 import UnliftIO.STM
 
 import Imports
@@ -34,19 +35,26 @@ waitConnectionWindowSize Context{txConnectionWindow} = do
 ----------------------------------------------------------------
 -- Receiving window update
 
-increaseStreamWindowSize :: Stream -> Int -> IO WindowSize
-increaseStreamWindowSize Stream{streamWindow} n = atomically $ do
-    w0 <- readTVar streamWindow
-    let w1 = w0 + n
-    writeTVar streamWindow w1
-    return w1
+increaseWindowSize :: StreamId -> TVar WindowSize -> WindowSize -> IO ()
+increaseWindowSize sid tvar n = do
+    w <- atomically $ do
+        w0 <- readTVar tvar
+        let w1 = w0 + n
+        writeTVar tvar w1
+        return w1
+    when (isWindowOverflow w) $ do
+        let msg = fromString ("window update for stream " ++ show sid ++ " is overflow")
+            err = if isControl sid then ConnectionErrorIsSent
+                                   else StreamErrorIsSent
+        E.throwIO $ err FlowControlError sid msg
 
-increaseConnectionWindowSize :: Context -> Int -> IO WindowSize
-increaseConnectionWindowSize Context{txConnectionWindow} n = atomically $ do
-    w0 <- readTVar txConnectionWindow
-    let w1 = w0 + n
-    writeTVar txConnectionWindow w1
-    return w1
+increaseStreamWindowSize :: Stream -> WindowSize -> IO ()
+increaseStreamWindowSize Stream{streamNumber,streamWindow} n =
+    increaseWindowSize streamNumber streamWindow n
+
+increaseConnectionWindowSize :: Context -> Int -> IO ()
+increaseConnectionWindowSize Context{txConnectionWindow} n =
+    increaseWindowSize 0 txConnectionWindow n
 
 decreaseWindowSize :: Context -> Stream -> WindowSize -> IO ()
 decreaseWindowSize Context{txConnectionWindow} Stream{streamWindow} siz = do
@@ -56,22 +64,21 @@ decreaseWindowSize Context{txConnectionWindow} Stream{streamWindow} siz = do
 ----------------------------------------------------------------
 -- Sending window update
 
-informWindowUpdate :: TQueue Control -> StreamId -> IORef Int -> Int -> IO ()
-informWindowUpdate _        _   _      0   = return ()
-informWindowUpdate controlQ sid incref len = do
-    -- incref is occupied by the receiver thread
-    w0 <- readIORef incref
-    let w1 = w0 + len
-    if w1 >= defaultWindowSize then do -- fixme
-        let frame = windowUpdateFrame sid w1
-        enqueueControl controlQ $ CFrames Nothing [frame]
-        writeIORef incref 0
-      else
-        writeIORef incref w1
-
-informConnectionWindowUpdate :: Context -> Int -> IO ()
-informConnectionWindowUpdate Context{..} =
-    informWindowUpdate controlQ 0 rxConnectionInc
+informWindowUpdate :: Context -> Stream -> IORef Int -> Int -> IO ()
+informWindowUpdate _        _   _       0   = return ()
+informWindowUpdate Context{controlQ,rxConnectionInc} Stream{streamNumber} streamInc len = do
+    join $ atomicModifyIORef rxConnectionInc $ modify 0
+    join $ atomicModifyIORef streamInc       $ modify streamNumber
+  where
+    modify sid w0
+      | w1 < thresh = (w1, return ())
+      | otherwise   = let frame = windowUpdateFrame sid w1
+                          cframe = CFrames Nothing [frame]
+                          action = enqueueControl controlQ cframe
+                      in (0, action)
+      where
+        thresh = defaultWindowSize -- fixme
+        w1 = w0 + len
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
- Adding debug information of stream error into GOAWAY which follows RST_STREAM
- Sending WINDOW_UPDATE  for connection (sid == 0) only when any bodies are consumed

@akshaymankar If you still meet RST_STREAM, please tell me the debug message in GOAWAY which immediately follows RST_STREAM.

