### PR TITLE
Generalize `Client`

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.HTTP2.Client.Run where

--- a/Network/HTTP2/Client/Types.hs
+++ b/Network/HTTP2/Client/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Network.HTTP2.Client.Types where
 
 import Network.HTTP2.Arch
@@ -5,7 +7,7 @@ import Network.HTTP2.Arch
 ----------------------------------------------------------------
 
 -- | Client type.
-type Client a = (Request -> (Response -> IO a) -> IO a) -> IO a
+type Client a = (forall b. Request -> (Response -> IO b) -> IO b) -> IO a
 
 -- | Request from client.
 newtype Request = Request OutObj deriving (Show)

--- a/test/HTTP2/ServerSpec.hs
+++ b/test/HTTP2/ServerSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
 
 module HTTP2.ServerSpec where
 
@@ -158,8 +159,18 @@ runClient allocConfig =
     runHTTP2Client s = E.bracket (allocConfig s 4096)
                                  freeSimpleConfig
                                  (\conf -> C.run cliconf conf client)
-    client sendRequest = mapConcurrently_ ($ sendRequest) clients
-    clients = [client0,client1,client2,client3,client3',client3'',client4,client5]
+
+    client :: C.Client ()
+    client sendRequest = mapConcurrently_ id $ [
+          client0   sendRequest
+        , client1   sendRequest
+        , client2   sendRequest
+        , client3   sendRequest
+        , client3'  sendRequest
+        , client3'' sendRequest
+        , client4   sendRequest
+        , client5   sendRequest
+        ]
 
 -- delay sending preface to be able to test if it is always sent first
 allocSlowPrefaceConfig :: Socket -> BufferSize -> IO Config

--- a/test/HTTP2/ServerSpec.hs
+++ b/test/HTTP2/ServerSpec.hs
@@ -11,8 +11,8 @@ import Control.Monad
 import Crypto.Hash (Context, SHA1) -- cryptonite
 import qualified Crypto.Hash as CH
 import qualified Data.ByteString as B
+import Data.ByteString (ByteString)
 import Data.ByteString.Builder (byteString, Builder)
-import Data.ByteString.Char8
 import qualified Data.ByteString.Char8 as C8
 import Data.IORef
 import Network.HTTP.Types
@@ -161,7 +161,7 @@ runClient allocConfig =
                                  (\conf -> C.run cliconf conf client)
 
     client :: C.Client ()
-    client sendRequest = mapConcurrently_ id $ [
+    client sendRequest = foldr1 concurrently_ $ [
           client0   sendRequest
         , client1   sendRequest
         , client2   sendRequest
@@ -180,7 +180,7 @@ allocSlowPrefaceConfig s size = do
   where
     slowPrefaceSend :: (ByteString -> IO ()) -> ByteString -> IO ()
     slowPrefaceSend orig chunk = do
-      when (C8.pack "PRI" `isPrefixOf` chunk) $ do
+      when (C8.pack "PRI" `C8.isPrefixOf` chunk) $ do
         threadDelay 10000
       orig chunk
 


### PR DESCRIPTION
The type of `run` is

```haskell
run :: ClientConfig -> Config -> Client a -> IO a
```

which looks reasonable enough. However, `Client` is a synonym for

```haskell
type Client a = (Request -> (Response -> IO a) -> IO a) -> IO a
```

The client is given a `sendRequest` function which it can use to send requests, as long as it provides a way to process the response. That too is reasonable, but the confusing part is the use of `a` in the type of `sendRequest`: why does this have to be related to the final result of the `Client`? It seems to suggest that perhaps all of these are collected in some way, but of course that cannot be the case since (the result would have to be `IO [a]` or something).

Indeed, if we look at the code, there _is_ no relation; in this commit we therefore generalize `Client` to

```haskell
type Client a = (forall b. Request -> (Response -> IO b) -> IO b) -> IO a
```

This makes more sense: we get a callback that we can call as often as we we like; whatever type we get back when we process the response is the result of that callback; and we then use this callback to produce the final result, whatever it is.

This requires _no_ code changes in the library at all; just needs `RankNTypes` enabled in a few modules.

**Backwards compatibility**: this is strictly a generalization of the existing API, so existing code will continue to work; it just gets a more precise type, and can do more. _However_, there is one limitation, which is why I had to modify one of the tests in the test suite: where before we could have a `[Client ()]`, that is no longer possible (as it would require impredicativity). I suspect that this will not really be an issue, but I do not know for sure.