### PR TITLE
Give spawned threads control over async exceptions

### DIFF
--- a/Network/HTTP2/Arch/Queue.hs
+++ b/Network/HTTP2/Arch/Queue.hs
@@ -10,7 +10,7 @@ import Network.HTTP2.Arch.Types
 {-# INLINE forkAndEnqueueWhenReady #-}
 forkAndEnqueueWhenReady :: IO () -> TQueue (Output Stream) -> Output Stream -> Manager -> IO ()
 forkAndEnqueueWhenReady wait outQ out mgr =
-    forkManaged mgr $ do
+    forkManaged mgr $ \unmask -> unmask $ do
         wait
         enqueueOutput outQ out
 

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -33,8 +33,8 @@ type Path = ByteString
 type InpBody = IO ByteString
 
 data OutBody = OutBodyNone
-             -- | Streaming body takes a write action and a flush action.
-             | OutBodyStreaming ((Builder -> IO ()) -> IO () -> IO ())
+             -- | Streaming body takes an unmask function, a write action and a flush action.
+             | OutBodyStreaming ((forall a. IO a -> IO a) -> (Builder -> IO ()) -> IO () -> IO ())
              | OutBodyBuilder Builder
              | OutBodyFile FileSpec
 

--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -123,7 +123,7 @@ requestBuilder m p hdr builder = Request $ OutObj hdr' (OutBodyBuilder builder) 
 
 -- | Creating request with streaming.
 requestStreaming :: Method -> Path -> RequestHeaders
-                 -> ((Builder -> IO ()) -> IO () -> IO ())
+                 -> ((forall a. IO a -> IO a) -> (Builder -> IO ()) -> IO () -> IO ())
                  -> Request
 requestStreaming m p hdr strmbdy = Request $ OutObj hdr' (OutBodyStreaming strmbdy) defaultTrailersMaker
   where

--- a/Network/HTTP2/Client/Types.hs
+++ b/Network/HTTP2/Client/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RankNTypes #-}
-
 module Network.HTTP2.Client.Types where
 
 import Network.HTTP2.Arch

--- a/Network/HTTP2/Server.hs
+++ b/Network/HTTP2/Server.hs
@@ -163,7 +163,7 @@ responseBuilder st hdr builder = Response $ OutObj hdr' (OutBodyBuilder builder)
 
 -- | Creating response with streaming.
 responseStreaming :: H.Status -> H.ResponseHeaders
-                  -> ((Builder -> IO ()) -> IO () -> IO ())
+                  -> ((forall a. IO a -> IO a) -> (Builder -> IO ()) -> IO () -> IO ())
                   -> Response
 responseStreaming st hdr strmbdy = Response $ OutObj hdr' (OutBodyStreaming strmbdy) defaultTrailersMaker
   where

--- a/http2.cabal
+++ b/http2.cabal
@@ -111,7 +111,7 @@ library
         Network.HTTP2.Server.Worker
 
     default-language:   Haskell2010
-    default-extensions: Strict StrictData
+    default-extensions: Strict StrictData RankNTypes
     ghc-options:        -Wall
     build-depends:
         base >=4.9 && <5,


### PR DESCRIPTION
@kazu-yamamoto , I'm not 100% sure if I got this right, because I don't yet have a complete picture of all the control flow in `http2`.

`http2` spawns various threads on behalf of the client code. The main idea is of this PR is to give that client code a way to handle asynchronous exceptions; specifically, to make sure that they have an exception handler of their own installed before async exceptions are enabled. 

The key change is this one:

```haskell
data OutBody = 
    .. 
    -- | Streaming body takes an unmask function, a write action and a flush action.
  | OutBodyStreaming ((forall a. IO a -> IO a) -> (Builder -> IO ()) -> IO () -> IO ())
```

### Client side

On the client side, I am fairly confident that what I have is right. I have modified `forkManaged` (from #74) to not call `unmask` directly, but instead pass it as an argument to the thread, so that _it_ can decide to unmask exceptions if and where it wants; we then just pass that on as an argument to the function in the `OutBodyStreaming`.

### Server side

On the server side, I am a bit less certain. Here threads are spawned by the manager; so I have changed the `Action` type to

```haskell
newtype Action = Action { runAction :: (forall a. IO a -> IO a) -> IO () }
```

I then propagate the `unmask` argument through, and in `response` pass it to the function inside `OutBodyStreaming`; for all other calls, I just call `unmask` directly (this is important, otherwise timeouts would not be possible).

What I am unsure about is if this limits the scope of where async exceptions are enabled too much; in particular, what about the rest of `go` in `worker`? 

### Alternative approach

So far, I have only really needed this on the client, I haven't started on the server side implementation of gRPC yet; so I'm not sure if this change is even _useful_ on the server side (mostly since those threads seem to do more than just execute user code).  I suspect that it is, but I don't have hard evidence for it currently.

The only reason I made the server modifications at this point is that the client and the server share the `OutBody` type. So an alternative approach would be to decouple these, and allow the client and the server to diverge in the type of the handler; those it's nice of course to have the consistency.

Finally, if you think that this whole thing is not a good idea and we should not give the user this control, then feel free to close the PR again; it allows me to make my async exception handling more airtight, but I don't depend on it critically.

(BTW, haven't forgotten about #76 , I will get to it soon.)