### PR TITLE
Handle `RST_STREAM`/`NO_ERROR`

### DIFF
--- a/Network/HTTP2/Arch/Receiver.hs
+++ b/Network/HTTP2/Arch/Receiver.hs
@@ -172,6 +172,8 @@ controlOrStream ctx@Context{..} conf@Config{..} ftyp header@FrameHeader{streamId
 ----------------------------------------------------------------
 
 processState :: StreamState -> Context -> Stream -> StreamId -> IO Bool
+
+-- Transition (process1)
 processState (Open (NoBody tbl@(_,reqvt))) ctx@Context{..} strm@Stream{streamInput} streamId = do
     let mcl = fst <$> (getHeaderValue tokenContentLength reqvt >>= C8.readInt)
     when (just mcl (/= (0 :: Int))) $ E.throwIO $ StreamErrorIsSent ProtocolError streamId "no body but content-length is not zero"
@@ -184,6 +186,8 @@ processState (Open (NoBody tbl@(_,reqvt))) ctx@Context{..} strm@Stream{streamInp
       else
         putMVar streamInput inpObj
     return False
+
+-- Transition (process2)
 processState (Open (HasBody tbl@(_,reqvt))) ctx@Context{..} strm@Stream{streamInput} _streamId = do
     let mcl = fst <$> (getHeaderValue tokenContentLength reqvt >>= C8.readInt)
     bodyLength <- newIORef 0
@@ -199,12 +203,18 @@ processState (Open (HasBody tbl@(_,reqvt))) ctx@Context{..} strm@Stream{streamIn
       else
         putMVar streamInput inpObj
     return False
+
+-- Transition (process3)
 processState s@(Open Continued{}) ctx strm _streamId = do
     setStreamState ctx strm s
     return True
+
+-- Transition (process4)
 processState HalfClosedRemote ctx strm _streamId = do
     halfClosedRemote ctx strm
     return False
+
+-- Transition (process5)
 processState s ctx strm _streamId = do
     -- Idle, Open Body, Closed
     setStreamState ctx strm s
@@ -326,6 +336,8 @@ checkPriority p me
     dep = streamDependency p
 
 stream :: FrameType -> FrameHeader -> ByteString -> Context -> StreamState -> Stream -> IO StreamState
+
+-- Transition (stream1)
 stream FrameHeaders header@FrameHeader{flags,streamId} bs ctx s@(Open JustOpened) Stream{streamNumber} = do
     HeadersFrame mp frag <- guardIt $ decodeHeadersFrame header bs
     let endOfStream = testEndStream flags
@@ -351,6 +363,7 @@ stream FrameHeaders header@FrameHeader{flags,streamId} bs ctx s@(Open JustOpened
             let siz = BS.length frag
             return $ Open $ Continued [frag] siz 1 endOfStream
 
+-- Transition (stream2)
 stream FrameHeaders header@FrameHeader{flags,streamId} bs ctx (Open (Body q _ _ tlr)) _ = do
     HeadersFrame _ frag <- guardIt $ decodeHeadersFrame header bs
     let endOfStream = testEndStream flags
@@ -376,6 +389,7 @@ stream FrameData
       else
         return s
 
+-- Transition (stream4)
 stream FrameData
        header@FrameHeader{flags,payloadLength,streamId}
        bs
@@ -404,6 +418,7 @@ stream FrameData
       else
         return s
 
+-- Transition (stream5)
 stream FrameContinuation FrameHeader{flags,streamId} frag ctx s@(Open (Continued rfrags siz n endOfStream)) _ = do
     let endOfHeader = testEndHeader flags
     if frag == "" && not endOfHeader then do
@@ -431,17 +446,20 @@ stream FrameContinuation FrameHeader{flags,streamId} frag ctx s@(Open (Continued
           else
             return $ Open $ Continued rfrags' siz' n' endOfStream
 
+-- (No state transition)
 stream FrameWindowUpdate header bs _ s strm = do
     WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
     increaseStreamWindowSize strm n
     return s
 
+-- (Not a true transition: throws an exception)
 stream FrameRSTStream header@FrameHeader{streamId} bs ctx _ strm = do
     RSTStreamFrame err <- guardIt $ decodeRSTStreamFrame header bs
     let cc = Reset err
     closed ctx strm cc
     E.throwIO $ StreamErrorIsReceived err streamId
 
+-- (No state transition)
 stream FramePriority header bs _ s Stream{streamNumber} = do
     -- ignore
     -- Resource Loop - CVE-2019-9513

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -105,6 +105,82 @@ data FileSpec = FileSpec FilePath FileOffset ByteCount deriving (Eq, Show)
 
 ----------------------------------------------------------------
 
+{-
+
+== Stream state
+
+The stream state is stored in the 'streamState' field (an @IORef@) of a
+'Stream'. The main place where the stream state is updated is in
+'controlOrStream', which does something like this:
+
+> state0 <- readStreamState strm
+> state1 <- stream .. state0 ..
+> processState .. state1 ..
+
+where 'processState' updates the @IORef@, based on 'state1' (the state computed
+by 'stream') and the /current/ state of the stream; for simplicity, we will
+assume here that this must equal 'state0' (it might not, if a concurrent thread
+changed the stream state).
+
+The diagram below summarizes the stream state transitions on the client side,
+omitting error cases (which result in exceptions being thrown). Each transition
+is labelled with the relevant case in either the function 'stream' or the
+function 'processState'.
+
+>                        [Open JustOpened]
+>                               |
+>                               |
+>                            HEADERS
+>                               |
+>                               | (stream1)
+>                               |
+>                          END_HEADERS?
+>                               |
+>                        ______/ \______
+>                       /   yes   no    \
+>                      |                |
+>                      |         [Open Continued] <--\
+>                      |                |            |
+>                      |           CONTINUATION      |
+>                      |                |            |
+>                      |                | (stream5)  |
+>                      |                |            |
+>                      |           END_HEADERS?      |
+>                      |                |            |
+>                      v           yes / \ no        |
+>                 END_STREAM? <-------/   \-----------/
+>                      |                   (process3)
+>                      |
+>            _________/ \_________
+>           /      yes   no       \
+>           |                     |
+>      [Open NoBody]        [Open HasBody]
+>           |                     |
+>           | (process1)          | (process2)
+>           |                     |
+>  [HalfClosedRemote] <--\   [Open Body] <----------------------\
+>                        |        |                             |
+>                        |        +---------------\             |
+>                        |        |               |             |
+>                        |     HEADERS           DATA           |
+>                        |        |               |             |
+>                        |        | (stream2)     | (stream4)   |
+>                        |        |               |             |
+>                        |   END_STREAM?      END_STREAM?       |
+>                        |        |               |             |
+>                        |        | yes      yes / \ no         |
+>                        \--------+-------------/   \-----------/
+>                         (process4)                 (process5)
+
+Notes:
+
+- The 'HalfClosedLocal' state is not used on the client side.
+- Indeed, unless an exception is thrown, even the 'Closed' stream state is not
+  used in the client; when the @IORef@ is collected, it is typically in
+  'HalfClosedRemote' state.
+
+-}
+
 data OpenState =
     JustOpened
   | Continued [HeaderBlockFragment]

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -159,18 +159,18 @@ function 'processState'.
 >           | (process1)          | (process2)
 >           |                     |
 >  [HalfClosedRemote] <--\   [Open Body] <----------------------\
->                        |        |                             |
->                        |        +---------------\             |
->                        |        |               |             |
->                        |     HEADERS           DATA           |
->                        |        |               |             |
->                        |        | (stream2)     | (stream4)   |
->                        |        |               |             |
->                        |   END_STREAM?      END_STREAM?       |
->                        |        |               |             |
->                        |        | yes      yes / \ no         |
->                        \--------+-------------/   \-----------/
->                         (process4)                 (process5)
+>           |             |        |                             |
+>           |             |        +---------------\             |
+>       RST_STREAM        |        |               |             |
+>           |             |     HEADERS           DATA           |
+>           | (stream6)   |        |               |             |
+>           |             |        | (stream2)     | (stream4)   |
+>           | (process5)  |        |               |             |
+>           |             |   END_STREAM?      END_STREAM?       |
+>        [Closed]         |        |               |             |
+>                         |        | yes      yes / \ no         |
+>                         \--------+-------------/   \-----------/
+>                          (process4)                 (process6)
 
 Notes:
 


### PR DESCRIPTION
This closes #76 .

@kazu-yamamoto , this is two commits.

1. In the first commit, I don't change any code at all, but I add a diagram in which I document the various stream state transitions and how they are implemented. I wanted to make sure that I understood these very well before adding a new transition (the one for `RST_STREAM`). The diagram I add in this commit does _not_ yet reflect the change I want to make, but rather the status quo prior to this PR.
2. In the second commit I then make the actual change, which was now actually quite simple; there were a few ways to do it, but for consistency I now _return_ the `Closed` stream state, which is then applied in `processState`; this matches what you do for all the other cases.

As I was working on my own library, I noticed that there is a second important use case for this fix (the first being the one I outline in #76): it's not just important when the server wants to tell the client "don't send any more here, we're done", but also when the server wants to tell the client "this particular method is not actually supported at all, don't even _start_ sending me anything". Not terribly relevant for you, except to let you know that I've tested both scenarios with the fix from this PR, and they are now both working correctly.

## Related bug?

However, something that had me concerned as I was documenting the state transitions: except in the case of `RST_STREAM`, a stream is _never_ really closed on the client side (as I mention below the diagram in the code, when the `streamState` `IORef` is collected, it is typically in `HalfClosedRemote` state). This doesn't matter by itself, but I started tracking when these are then GCed, and it appears that they are not GCed at all, until the entire connection to the server is closed. 

What I would have _expected_ to see when I started documenting all the state transitions is that when the client sends their final message (meaning, the thread that gets spawned by `requestStreaming` terminates), the connection transitions to `HalfClosedLocal`, at which point it can be closed entirely and forgotten about once the server closes their end too. What do you think? Should I try to submit a PR for that, also, or have I misunderstood what the intended control flow?

(I can open a separate issue about this if that's better.)

