### PR TITLE
Don't use generic `ThreadKilled`

### DIFF
--- a/Network/HTTP2/Internal.hs
+++ b/Network/HTTP2/Internal.hs
@@ -24,8 +24,11 @@ module Network.HTTP2.Internal (
   , defaultTrailersMaker
   , NextTrailersMaker(..)
   , runTrailersMaker
-  )  where
+  -- * Exceptions
+  , KilledByHttp2ThreadPoolManager(..)
+  ) where
 
 import Network.HTTP2.Arch.File
-import Network.HTTP2.Arch.Types
+import Network.HTTP2.Arch.Manager
 import Network.HTTP2.Arch.Sender
+import Network.HTTP2.Arch.Types


### PR DESCRIPTION
By using a specific exception debugging of client code becomes easier: when we see a thread killed using `ThreadKilled`, it could come from anywhere, but when we see a thread killed using `KilledByHttp2ThreadPoolManager`, it can only come from one place.