### PR TITLE
Introduce `OutBodyStreamingUnmask`

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | HTTP\/2 client library.
 --
@@ -58,6 +59,7 @@ module Network.HTTP2.Client (
   , requestNoBody
   , requestFile
   , requestStreaming
+  , requestStreamingUnmask
   , requestBuilder
   -- ** Trailers maker
   , TrailersMaker
@@ -129,6 +131,13 @@ requestStreaming m p hdr strmbdy = Request $ OutObj hdr' (OutBodyStreaming strmb
   where
     hdr' = addHeaders m p hdr
 
+-- | Like 'requestStreaming', but run the action with exceptions masked
+requestStreamingUnmask :: Method -> Path -> RequestHeaders
+                       -> ((forall x. IO x -> IO x) -> (Builder -> IO ()) -> IO () -> IO ())
+                       -> Request
+requestStreamingUnmask m p hdr strmbdy = Request $ OutObj hdr' (OutBodyStreamingUnmask strmbdy) defaultTrailersMaker
+  where
+    hdr' = addHeaders m p hdr
 
 addHeaders :: Method -> Path -> RequestHeaders -> RequestHeaders
 addHeaders m p hdr = (":method", m) : (":path", p) : hdr

--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -14,6 +14,7 @@ import Imports
 import Network.HTTP2.Arch
 import Network.HTTP2.Client.Types
 import Network.HTTP2.Frame
+import Data.ByteString.Builder (Builder)
 
 -- | Client configuration
 data ClientConfig = ClientConfig {
@@ -69,22 +70,10 @@ sendRequest ctx@Context{..} mgr scheme auth (Request req) processResponse = do
           sid <- getMyNewStreamId ctx
           newstrm <- openStream ctx sid FrameHeaders
           case outObjBody req of
-            OutBodyStreaming strmbdy -> do
-                tbq <- newTBQueueIO 10 -- fixme: hard coding: 10
-                tbqNonMmpty <- newTVarIO False
-                forkManaged mgr $ do
-                    let push b = atomically $ do
-                            writeTBQueue tbq (StreamingBuilder b)
-                            writeTVar tbqNonMmpty True
-                        flush  = atomically $ writeTBQueue tbq StreamingFlush
-                    strmbdy push flush
-                    atomically $ writeTBQueue tbq StreamingFinished
-                atomically $ do
-                    sidOK <- readTVar outputQStreamID
-                    ready <- readTVar tbqNonMmpty
-                    check (sidOK == sid && ready)
-                    writeTVar outputQStreamID (sid + 2)
-                    writeTQueue outputQ $ Output newstrm req' OObj (Just tbq) (return ())
+            OutBodyStreaming strmbdy ->
+                stream req' sid newstrm $ \unmask push flush -> unmask $ strmbdy push flush
+            OutBodyStreamingUnmask strmbdy ->
+                stream req' sid newstrm strmbdy
             _ -> atomically $ do
                 sidOK <- readTVar outputQStreamID
                 check (sidOK == sid)
@@ -94,6 +83,24 @@ sendRequest ctx@Context{..} mgr scheme auth (Request req) processResponse = do
       Just strm0 -> return strm0
     rsp <- takeMVar $ streamInput strm
     processResponse $ Response rsp
+  where
+    stream :: OutObj -> StreamId -> Stream -> ((forall x. IO x -> IO x) -> (Builder -> IO ()) -> IO () -> IO ()) -> IO ()
+    stream req' sid newstrm strmbdy = do
+        tbq <- newTBQueueIO 10 -- fixme: hard coding: 10
+        tbqNonMmpty <- newTVarIO False
+        forkManagedUnmask mgr $ \unmask -> do
+            let push b = atomically $ do
+                    writeTBQueue tbq (StreamingBuilder b)
+                    writeTVar tbqNonMmpty True
+                flush  = atomically $ writeTBQueue tbq StreamingFlush
+            strmbdy unmask push flush
+            atomically $ writeTBQueue tbq StreamingFinished
+        atomically $ do
+            sidOK <- readTVar outputQStreamID
+            ready <- readTVar tbqNonMmpty
+            check (sidOK == sid && ready)
+            writeTVar outputQStreamID (sid + 2)
+            writeTQueue outputQ $ Output newstrm req' OObj (Just tbq) (return ())
 
 exchangeSettings :: Config -> Context -> IO ()
 exchangeSettings conf ctx@Context{..} = do

--- a/Network/HTTP2/Server/Worker.hs
+++ b/Network/HTTP2/Server/Worker.hs
@@ -143,6 +143,8 @@ response wc@WorkerConf{..} mgr th tconf strm (Request req) (Response rsp) pps = 
       -- manager will not terminate it before we are done. (The thread ID was
       -- added implicitly when the worker was spawned by the manager).
       deleteMyId mgr
+  OutBodyStreamingUnmask _ ->
+    error "response: server does not support OutBodyStreamingUnmask"
   where
     (_,reqvt) = inpObjHeaders req
 


### PR DESCRIPTION
This is a new attempt at providing an `unmask` callback to streaming requests, replacing #77. 

As per the discussion in #77, I've new introduced `OutBodyStreamingUnmask` alongside `OutBodyStreaming`. 

This was actually a useful change. When I first wrote #77, I didn't really understand the server part of `http2` very well yet, as I had not yet implemented the server part of my gRPC library. I now have, and understand the server aspect of `http2` much better. My suspicion in #77 that I might have gotten the control flow wrong for the server API turned out to be correct: the point of this change is that user code gets control over when exceptions are unmasked in newly spawned threads. On the client side, that newly spawned thread is created in `sendRequest` (in `Network.HTTP2.Client.Run`). On the server-side, however, this works a bit differently: `http2` spawns a new thread for each incoming request (call to `setAction` in `run`, `Network.HTTP2.Server.Run`); it then does _not_ spawn a new thread for a streaming response body. 

Therefore, this PR _only_ deals with the client side, and `OutBodyStreamingUnmask` is not actually supported at all on the server side (this PR introduces `requestStreamingUnmask`, without a corresponding `responseStreamingUnmask`). It _might_ be useful to change the `Server` type synonym so that the `server` action passed to `run` would also be given an `unmask` callback, but that has now become orthogonal to this PR. 