### PR TITLE
Record reason in `KilledByHttp2ThreadPoolManager`

### DIFF
--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -4,13 +4,13 @@
 module Network.HTTP2.Server.Run where
 
 import UnliftIO.Async (concurrently_)
-import qualified UnliftIO.Exception as E
 
 import Imports
 import Network.HTTP2.Arch
 import Network.HTTP2.Frame
 import Network.HTTP2.Server.Types
 import Network.HTTP2.Server.Worker
+import Control.Exception
 
 ----------------------------------------------------------------
 
@@ -33,7 +33,12 @@ run conf@Config{..} server = do
         replicateM_ 3 $ spawnAction mgr
         let runReceiver = frameReceiver ctx conf
             runSender   = frameSender   ctx conf mgr
-        concurrently_ runReceiver runSender `E.finally` stop mgr
+        stopAfter mgr (concurrently_ runReceiver runSender) $ \res -> do
+          case res of
+            Left err ->
+              throwIO err
+            Right x ->
+              return x
   where
     checkPreface = do
         preface <- confReadN connectionPrefaceLength


### PR DESCRIPTION
This is the first patch of a series of three patches; this first patch is primarily preparatory: it records the reason a server handler is killed as part of the `KilledByHttp2ThreadPoolManager`. This primarily helps debugging, but it can also serve some other functions; more on that in the next patch.