### PR TITLE
Close all streams on termination

### DIFF
--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -204,7 +204,7 @@ data OpenState =
               Bool -- End of stream
   | NoBody HeaderTable
   | HasBody HeaderTable
-  | Body (TQueue ByteString)
+  | Body (TQueue (Either SomeException ByteString))
          (Maybe Int) -- received Content-Length
                      -- compared the body length for error checking
          (IORef Int) -- actual body length

--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -40,6 +40,7 @@ run ClientConfig{..} conf@Config{..} client = do
             enqueueControl (controlQ ctx) $ CFrames Nothing [frame]
             return x
     stopAfter mgr (race runBackgroundThreads runClient) $ \res -> do
+      closeAllStreams (streamTable ctx) $ either Just (const Nothing) res
       case res of
         Left err ->
           throwIO err

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -4,13 +4,13 @@
 module Network.HTTP2.Server.Run where
 
 import UnliftIO.Async (concurrently_)
-import qualified UnliftIO.Exception as E
 
 import Imports
 import Network.HTTP2.Arch
 import Network.HTTP2.Frame
 import Network.HTTP2.Server.Types
 import Network.HTTP2.Server.Worker
+import Control.Exception
 
 ----------------------------------------------------------------
 
@@ -33,7 +33,12 @@ run conf@Config{..} server = do
         replicateM_ 3 $ spawnAction mgr
         let runReceiver = frameReceiver ctx conf
             runSender   = frameSender   ctx conf mgr
-        concurrently_ runReceiver runSender `E.finally` stop mgr
+        stopAfter mgr (concurrently_ runReceiver runSender) $ \res -> do
+          case res of
+            Left err ->
+              throwIO err
+            Right x ->
+              return x
   where
     checkPreface = do
         preface <- confReadN connectionPrefaceLength

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -34,6 +34,7 @@ run conf@Config{..} server = do
         let runReceiver = frameReceiver ctx conf
             runSender   = frameSender   ctx conf mgr
         stopAfter mgr (concurrently_ runReceiver runSender) $ \res -> do
+          closeAllStreams (streamTable ctx) $ either Just (const Nothing) res
           case res of
             Left err ->
               throwIO err


### PR DESCRIPTION
This is the second patch in a patch set of three patches, the first being #82 (the first commit in this PR _is_ #82).

When a client disconnects, `http2` kills the corresponding handlers. This may be fine for a webserver where the handler is just feeding the client information, but it's not fine in the general case. For example, I am building a gRPC library; when a client makes a remote procedure call, the server handler _must_ have the option to terminate cleanly; after all, an RPC could be anything, and the server might need to execute some code after the client has told it all it needs to; maybe it needs to write to a database, maybe it needs to make RPC calls of its own, maybe a lot of things; simply killing the handler is not ok.

In my library I am isolating the handler from the `KilledByHttp2ThreadPoolManager` exception by running it in a separate thread; when the parent thread receives the `KilledByHttp2ThreadPoolManager` exception, it marks some local state to indicate that the handler is no longer able to send anything to the client. _If_ the handler attempts to do so at this point, an exception will be raised, but otherwise the handler is allowed to continue.

On the input side things are more complicated, however, which is where this PR comes in. While it is possible to have some local state indicating that the handler shouldn't expect any more input from the client either, there might still be unprocessed input from the client in the `TQueue`. We don't get that direct access to that `TQueue` in the `http2` API; all we have is `getRequestBodyChunk`; this makes it difficult to write code that says "check this local piece of state but only if the `TQueue` is exhausted".

Prior to this PR, if we call `getRequestBodyChunk` when the `TQueue` is _empty_, we get an exception, but not a useful one ("thread blocked indefinitely"). This PR changes this by making two changes:

1. The `TQueue` can carry an exception; when we encounter this exception, it will be raised in `getRequestBodyChunk`. 
2. When we terminate, we close all still open streams; if we terminated normally (that is, `ConnectionIsClosed`) we write an empty bytestring to the queue, to allow handlers to detect normal client termination; if we terminate with any other exception, we write that exception to the queue, allowing the handler to detect that the client terminated with an exception.

