### PR TITLE
Delete `HalfClosedLocal`

### DIFF
--- a/Network/HTTP2/Arch/Context.hs
+++ b/Network/HTTP2/Arch/Context.hs
@@ -163,20 +163,8 @@ halfClosedRemote ctx stream@Stream{streamState} = do
     traverse_ (closed ctx stream) closingCode
   where
     closeHalf :: StreamState -> (StreamState, Maybe ClosedCode)
-    closeHalf x@(Closed _)         = (x, Nothing)
-    closeHalf (HalfClosedLocal cc) = (Closed cc, Just cc)
-    closeHalf _                    = (HalfClosedRemote, Nothing)
-
-halfClosedLocal :: Context -> Stream -> ClosedCode -> IO ()
-halfClosedLocal ctx stream@Stream{streamState} cc = do
-    shouldFinalize <- atomicModifyIORef streamState closeHalf
-    when shouldFinalize $
-        closed ctx stream cc
-  where
-    closeHalf :: StreamState -> (StreamState, Bool)
-    closeHalf x@(Closed _)     = (x, False)
-    closeHalf HalfClosedRemote = (Closed cc, True)
-    closeHalf _                = (HalfClosedLocal cc, False)
+    closeHalf x@(Closed _) = (x, Nothing)
+    closeHalf _            = (HalfClosedRemote, Nothing)
 
 closed :: Context -> Stream -> ClosedCode -> IO ()
 closed ctx@Context{concurrency,streamTable} strm@Stream{streamNumber} cc = do

--- a/Network/HTTP2/Arch/Receiver.hs
+++ b/Network/HTTP2/Arch/Receiver.hs
@@ -382,18 +382,6 @@ stream FrameHeaders header@FrameHeader{flags,streamId} bs ctx (Open (Body q _ _ 
         -- we don't support continuation here.
         E.throwIO $ ConnectionErrorIsSent ProtocolError streamId "continuation in trailer is not supported"
 
--- ignore data-frame except for flow-control when we're done locally
-stream FrameData
-       FrameHeader{flags}
-       _bs
-       _ctx s@(HalfClosedLocal _)
-       _ = do
-    let endOfStream = testEndStream flags
-    if endOfStream then do
-        return HalfClosedRemote
-      else
-        return s
-
 -- Transition (stream4)
 stream FrameData
        header@FrameHeader{flags,payloadLength,streamId}

--- a/Network/HTTP2/Arch/Stream.hs
+++ b/Network/HTTP2/Arch/Stream.hs
@@ -27,11 +27,6 @@ isHalfClosedRemote HalfClosedRemote = True
 isHalfClosedRemote (Closed _)       = True
 isHalfClosedRemote _                = False
 
-isHalfClosedLocal :: StreamState -> Bool
-isHalfClosedLocal (HalfClosedLocal _) = True
-isHalfClosedLocal (Closed _)       = True
-isHalfClosedLocal _                = False
-
 isClosed :: StreamState -> Bool
 isClosed Closed{} = True
 isClosed _        = False

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -222,17 +222,15 @@ data StreamState =
     Idle
   | Open OpenState
   | HalfClosedRemote
-  | HalfClosedLocal ClosedCode
   | Closed ClosedCode
   | Reserved
 
 instance Show StreamState where
-    show Idle                = "Idle"
-    show Open{}              = "Open"
-    show HalfClosedRemote    = "HalfClosedRemote"
-    show (HalfClosedLocal e) = "HalfClosedLocal: " ++ show e
-    show (Closed e)          = "Closed: " ++ show e
-    show Reserved            = "Reserved"
+    show Idle             = "Idle"
+    show Open{}           = "Open"
+    show HalfClosedRemote = "HalfClosedRemote"
+    show (Closed e)       = "Closed: " ++ show e
+    show Reserved         = "Reserved"
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
This is the third patch in a patch set of three patches; the first two are #82 and #83, although this PR does not strictly speaking depend on those two PRs (at least in the sense that it can build without).

@kazu-yamamoto , before I explain this PR , a side note: this is the PR I am least sure about, because it's a bit "aggressive": it makes a relatively big change to the library, and it's possible that I've not taken something into account and we need to find a different solution. If that is the case, please let me know. 

The motivation for this PR has the same general theme as the motivation for #83. Prior to this PR, the `http2` library assumes that once the server closes its write end of a stream, any data frames sent on that stream by the client to the server can silently be ignored. This is perhaps also justified in the web server case: if the only purpose of the input from the client is to tell the server what information to send, then if the server is _done_ sending information, no further input from the client is required.

However, in the general case again this is not ok. My use case is remote procedure calls (gRPC); it's entirely possible that after the server has finished sending information to the client (including HTTP2 trailers), the client might still need to send a lot of information to the server. Indeed, other than "the client is the node that initiates the request", there isn't _really_ a major difference between client and server in gRPC. For example, the client might contact the server, say "I'm going to stream some information to you, after you give me some parameters"; the server might respond with those parameters, and then the client might start streaming that information to the server. 

So this PR makes perhaps a bit of an extreme change: it removes the `HalfClosedLocal` state from `http2` entirely. It was already not used on the client side; now it's also not used on the server side (it no longer exists). This means that even when the server closes their end of a stream, any data frames coming from the client are still processed as normal. 

I don't _think_ this will cause issues for other use cases, however, I cannot be completely sure; this is where I am a little uncertain about this PR. After all, there must be a reason why the `HalfClosedLocal` state was introduced in the first place? So, if we need a different solution here, please do let me know. 