### PR TITLE
Adding sockaddr

### DIFF
--- a/Network/HTTP2/Arch/Config.hs
+++ b/Network/HTTP2/Arch/Config.hs
@@ -25,6 +25,10 @@ data Config = Config {
     , confReadN       :: Int -> IO ByteString
     , confPositionReadMaker :: PositionReadMaker
     , confTimeoutManager :: T.Manager
+    -- | This is copied into 'Aux', if exist, on server.
+    , confMySockAddr     :: Maybe SockAddr
+    -- | This is copied into 'Aux', if exist, on server.
+    , confPeerSockAddr   :: Maybe SockAddr
     }
 
 -- | Making simple configuration whose IO is not efficient.
@@ -34,6 +38,8 @@ allocSimpleConfig s bufsiz = do
     buf <- mallocBytes bufsiz
     ref <- newIORef Nothing
     timmgr <- T.initialize $ 30 * 1000000
+    mysa <- getSocketName s
+    peersa <- getPeerName s
     let config = Config {
             confWriteBuffer = buf
           , confBufferSize = bufsiz
@@ -41,6 +47,8 @@ allocSimpleConfig s bufsiz = do
           , confReadN = defaultReadN s ref
           , confPositionReadMaker = defaultPositionReadMaker
           , confTimeoutManager = timmgr
+          , confMySockAddr   = Just mysa
+          , confPeerSockAddr = Just peersa
           }
     return config
 

--- a/Network/HTTP2/Arch/Config.hs
+++ b/Network/HTTP2/Arch/Config.hs
@@ -26,9 +26,9 @@ data Config = Config {
     , confPositionReadMaker :: PositionReadMaker
     , confTimeoutManager :: T.Manager
     -- | This is copied into 'Aux', if exist, on server.
-    , confMySockAddr     :: Maybe SockAddr
+    , confMySockAddr     :: SockAddr
     -- | This is copied into 'Aux', if exist, on server.
-    , confPeerSockAddr   :: Maybe SockAddr
+    , confPeerSockAddr   :: SockAddr
     }
 
 -- | Making simple configuration whose IO is not efficient.
@@ -47,8 +47,8 @@ allocSimpleConfig s bufsiz = do
           , confReadN = defaultReadN s ref
           , confPositionReadMaker = defaultPositionReadMaker
           , confTimeoutManager = timmgr
-          , confMySockAddr   = Just mysa
-          , confPeerSockAddr = Just peersa
+          , confMySockAddr   = mysa
+          , confPeerSockAddr = peersa
           }
     return config
 

--- a/Network/HTTP2/Arch/Context.hs
+++ b/Network/HTTP2/Arch/Context.hs
@@ -4,6 +4,7 @@ module Network.HTTP2.Arch.Context where
 
 import Data.IORef
 import Network.HTTP.Types (Method)
+import Network.Socket (SockAddr)
 import UnliftIO.STM
 
 import Imports hiding (insert)
@@ -87,12 +88,14 @@ data Context = Context {
   , pingRate           :: Rate
   , settingsRate       :: Rate
   , emptyFrameRate     :: Rate
+  , mySockAddr         :: Maybe SockAddr
+  , peerSockAddr       :: Maybe SockAddr
   }
 
 ----------------------------------------------------------------
 
-newContext :: RoleInfo -> BufferSize -> IO Context
-newContext rinfo siz =
+newContext :: RoleInfo -> BufferSize -> Maybe SockAddr -> Maybe SockAddr -> IO Context
+newContext rinfo siz mysa peersa =
     Context rl rinfo
                <$> newIORef False
                <*> newIORef Nothing
@@ -115,6 +118,8 @@ newContext rinfo siz =
                <*> newRate
                <*> newRate
                <*> newRate
+               <*> return mysa
+               <*> return peersa
    where
      rl = case rinfo of
        RIC{} -> Client

--- a/Network/HTTP2/Arch/Context.hs
+++ b/Network/HTTP2/Arch/Context.hs
@@ -88,13 +88,13 @@ data Context = Context {
   , pingRate           :: Rate
   , settingsRate       :: Rate
   , emptyFrameRate     :: Rate
-  , mySockAddr         :: Maybe SockAddr
-  , peerSockAddr       :: Maybe SockAddr
+  , mySockAddr         :: SockAddr
+  , peerSockAddr       :: SockAddr
   }
 
 ----------------------------------------------------------------
 
-newContext :: RoleInfo -> BufferSize -> Maybe SockAddr -> Maybe SockAddr -> IO Context
+newContext :: RoleInfo -> BufferSize -> SockAddr -> SockAddr -> IO Context
 newContext rinfo siz mysa peersa =
     Context rl rinfo
                <$> newIORef False

--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -27,7 +27,7 @@ data ClientConfig = ClientConfig {
 run :: ClientConfig -> Config -> Client a -> IO a
 run ClientConfig{..} conf@Config{..} client = do
     clientInfo <- newClientInfo scheme authority cacheLimit
-    ctx <- newContext clientInfo confBufferSize
+    ctx <- newContext clientInfo confBufferSize confMySockAddr confPeerSockAddr
     mgr <- start confTimeoutManager
     let runBackgroundThreads = do
             let runReceiver = frameReceiver ctx conf

--- a/Network/HTTP2/Server.hs
+++ b/Network/HTTP2/Server.hs
@@ -49,6 +49,8 @@ module Network.HTTP2.Server (
   -- * Aux
   , Aux
   , auxTimeHandle
+  , auxMySockAddr
+  , auxPeerSockAddr
   -- * Response
   , Response
   -- ** Creating response

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -20,7 +20,7 @@ run conf@Config{..} server = do
     ok <- checkPreface
     when ok $ do
         serverInfo <- newServerInfo
-        ctx <- newContext serverInfo confBufferSize
+        ctx <- newContext serverInfo confBufferSize confMySockAddr confPeerSockAddr
         -- Workers, worker manager and timer manager
         mgr <- start confTimeoutManager
         let wc = fromContext ctx

--- a/Network/HTTP2/Server/Types.hs
+++ b/Network/HTTP2/Server/Types.hs
@@ -37,7 +37,7 @@ data Aux = Aux {
     -- | Time handle for the worker processing this request and response.
     auxTimeHandle  :: T.Handle
     -- | Local socket address copied from 'Config'.
-  , auxMySockAddr  :: Maybe SockAddr
+  , auxMySockAddr   :: SockAddr
     -- | Remove socket address copied from 'Config'.
-  , auxPeerSockAddr :: Maybe SockAddr
+  , auxPeerSockAddr :: SockAddr
   }

--- a/Network/HTTP2/Server/Types.hs
+++ b/Network/HTTP2/Server/Types.hs
@@ -1,5 +1,6 @@
 module Network.HTTP2.Server.Types where
 
+import Network.Socket (SockAddr)
 import qualified System.TimeManager as T
 
 import Imports
@@ -32,7 +33,11 @@ data PushPromise = PushPromise {
     }
 
 -- | Additional information.
-newtype Aux = Aux {
+data Aux = Aux {
     -- | Time handle for the worker processing this request and response.
-    auxTimeHandle :: T.Handle
+    auxTimeHandle  :: T.Handle
+    -- | Local socket address copied from 'Config'.
+  , auxMySockAddr  :: Maybe SockAddr
+    -- | Remove socket address copied from 'Config'.
+  , auxPeerSockAddr :: Maybe SockAddr
   }

--- a/Network/HTTP2/Server/Worker.hs
+++ b/Network/HTTP2/Server/Worker.hs
@@ -33,8 +33,8 @@ data WorkerConf a = WorkerConf {
   , isPushable     :: IO Bool
   , insertStream   :: StreamId -> a -> IO ()
   , makePushStream :: a -> PushPromise -> IO (StreamId, StreamId, a)
-  , mySockAddr     :: Maybe SockAddr
-  , peerSockAddr   :: Maybe SockAddr
+  , mySockAddr     :: SockAddr
+  , peerSockAddr   :: SockAddr
   }
 
 fromContext :: Context -> WorkerConf Stream


### PR DESCRIPTION
My project (DNS over HTTP/2) requires to log a pair of socket addresses.

This provides my `SockAddr` and peer's `SockAddr` through `Aux` to `Server`.
`Config` has breaking changes.
If `http2-tls` is used, these changes are not visible.

Cc: @edsko @epoberezkin