### PR TITLE
Half closed local

### DIFF
--- a/Network/HTTP2/Arch/Receiver.hs
+++ b/Network/HTTP2/Arch/Receiver.hs
@@ -361,6 +361,7 @@ stream FrameHeaders header@FrameHeader{flags,streamId} bs ctx s@(Open hcl JustOp
         if endOfHeader then do
             tbl <- hpackDecodeHeader frag streamId ctx
             return $ if endOfStream then
+                       -- turned into HalfClosedRemote in processState
                         Open hcl (NoBody tbl)
                        else
                         Open hcl (HasBody tbl)
@@ -433,6 +434,7 @@ stream FrameContinuation FrameHeader{flags,streamId} frag ctx s@(Open hcl (Conti
             let hdrblk = BS.concat $ reverse rfrags'
             tbl <- hpackDecodeHeader hdrblk streamId ctx
             return $ if endOfStream then
+                        -- turned into HalfClosedRemote in processState
                         Open hcl (NoBody tbl)
                        else
                         Open hcl (HasBody tbl)

--- a/Network/HTTP2/Arch/Stream.hs
+++ b/Network/HTTP2/Arch/Stream.hs
@@ -28,9 +28,9 @@ isHalfClosedRemote (Closed _)       = True
 isHalfClosedRemote _                = False
 
 isHalfClosedLocal :: StreamState -> Bool
-isHalfClosedLocal (HalfClosedLocal _) = True
-isHalfClosedLocal (Closed _)       = True
-isHalfClosedLocal _                = False
+isHalfClosedLocal (Open (Just _) _) = True
+isHalfClosedLocal (Closed _)        = True
+isHalfClosedLocal _                 = False
 
 isClosed :: StreamState -> Bool
 isClosed Closed{} = True
@@ -83,7 +83,7 @@ closeAllStreams (StreamTable ref) mErr' = do
     forM_ strms $ \strm -> do
       st <- readStreamState strm
       case st of
-        Open (Body q _ _ _) ->
+        Open _ (Body q _ _ _) ->
           atomically $ writeTQueue q $ maybe (Right mempty) Left mErr
         _otherwise ->
           return ()

--- a/Network/HTTP2/Arch/Types.hs
+++ b/Network/HTTP2/Arch/Types.hs
@@ -220,17 +220,16 @@ data ClosedCode = Finished
 
 data StreamState =
     Idle
-  | Open OpenState
+  | Open (Maybe ClosedCode) OpenState -- HalfClosedLocal if Just
   | HalfClosedRemote
-  | HalfClosedLocal ClosedCode
   | Closed ClosedCode
   | Reserved
 
 instance Show StreamState where
     show Idle                = "Idle"
-    show Open{}              = "Open"
+    show (Open Nothing _)    = "Open"
+    show (Open (Just e) _)   = "HalfClosedLocal: " ++ show e
     show HalfClosedRemote    = "HalfClosedRemote"
-    show (HalfClosedLocal e) = "HalfClosedLocal: " ++ show e
     show (Closed e)          = "Closed: " ++ show e
     show Reserved            = "Reserved"
 


### PR DESCRIPTION
@edsko This should take over #84.

Rather than removing `HalfClosedLocal`, this patch integrates it into `Open`.

With the first commit, a test case fails.
That's why I added `isServer`.

The second commit does this integration.
The test case passes.