### PR TITLE
Improving the thread manager

### DIFF
--- a/Network/HTTP2/Arch/Manager.hs
+++ b/Network/HTTP2/Arch/Manager.hs
@@ -14,7 +14,7 @@ module Network.HTTP2.Arch.Manager (
   , forkManagedUnmask
   , timeoutKillThread
   , timeoutClose
-  , KilledByHttp2ThreadPoolManager(..)
+  , KilledByHttp2ThreadManager(..)
   , incCounter
   , decCounter
   , waitCounter0
@@ -142,7 +142,7 @@ del tid set = set'
     set' = Set.delete tid set
 
 kill :: Set ThreadId -> Maybe SomeException -> IO ()
-kill set err = traverse_ (\tid -> E.throwTo tid $ KilledByHttp2ThreadPoolManager err) set
+kill set err = traverse_ (\tid -> E.throwTo tid $ KilledByHttp2ThreadManager err) set
 
 -- | Killing the IO action of the second argument on timeout.
 timeoutKillThread :: Manager -> (T.Handle -> IO ()) -> IO ()
@@ -157,10 +157,10 @@ timeoutClose (Manager _ _ _ tmgr) closer = do
     th <- T.register tmgr closer
     return $ T.tickle th
 
-data KilledByHttp2ThreadPoolManager = KilledByHttp2ThreadPoolManager (Maybe SomeException)
+data KilledByHttp2ThreadManager = KilledByHttp2ThreadManager (Maybe SomeException)
   deriving Show
 
-instance Exception KilledByHttp2ThreadPoolManager where
+instance Exception KilledByHttp2ThreadManager where
   toException   = asyncExceptionToException
   fromException = asyncExceptionFromException
 

--- a/Network/HTTP2/Arch/Manager.hs
+++ b/Network/HTTP2/Arch/Manager.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 
--- | A thread pool manager.
+-- | A thread manager.
 --   The manager has responsibility to spawn and kill
 --   worker threads.
 module Network.HTTP2.Arch.Manager (
@@ -43,10 +43,10 @@ noAction = return ()
 
 data Command = Stop (Maybe SomeException) | Spawn | Add ThreadId | Delete ThreadId
 
--- | Manager to manage the thread pool and the timer.
+-- | Manager to manage the thread and the timer.
 data Manager = Manager (TQueue Command) (IORef Action) (TVar Int) T.Manager
 
--- | Starting a thread pool manager.
+-- | Starting a thread manager.
 --   Its action is initially set to 'return ()' and should be set
 --   by 'setAction'. This allows that the action can include
 --   the manager itself.

--- a/Network/HTTP2/Internal.hs
+++ b/Network/HTTP2/Internal.hs
@@ -24,8 +24,8 @@ module Network.HTTP2.Internal (
   , defaultTrailersMaker
   , NextTrailersMaker(..)
   , runTrailersMaker
-  -- * Exceptions
-  , KilledByHttp2ThreadPoolManager(..)
+  -- * Thread Manager
+  , module Network.HTTP2.Arch.Manager
   ) where
 
 import Network.HTTP2.Arch.File

--- a/Network/HTTP2/Server/Worker.hs
+++ b/Network/HTTP2/Server/Worker.hs
@@ -144,10 +144,6 @@ response wc@WorkerConf{..} mgr th tconf strm (Request req) (Response rsp) pps = 
           finished = atomically $ writeTBQueue tbq $ StreamingFinished (decCounter mgr)
       incCounter mgr
       strmbdy push flush `E.finally` finished
-      -- Remove the thread's ID from the manager's queue, to ensure the that the
-      -- manager will not terminate it before we are done. (The thread ID was
-      -- added implicitly when the worker was spawned by the manager).
-      deleteMyId mgr
   OutBodyStreamingUnmask _ ->
     error "response: server does not support OutBodyStreamingUnmask"
   where

--- a/Network/HTTP2/Server/Worker.hs
+++ b/Network/HTTP2/Server/Worker.hs
@@ -171,7 +171,7 @@ worker wc@WorkerConf{..} mgr server = do
             Right () -> return True
             Left e@(SomeException _)
               -- killed by the local worker manager
-              | Just KilledByHttp2ThreadPoolManager{} <- E.fromException e -> return False
+              | Just KilledByHttp2ThreadManager{} <- E.fromException e -> return False
               -- killed by the local timeout manager
               | Just T.TimeoutThread <- E.fromException e -> do
                   cleanup sinfo


### PR DESCRIPTION
@edsko I'm trying to use the thread manager from `http3`. This PR provides the followings. What do you think?

- Exporting the thread manager APIs.
- "Spawn" ensures to delete the thread id of newly spawned thread.
- `KilledByHttp2ThreadPoolManager` -> `KilledByHttp2ThreadManager`: thread pool means worker pool. But this manager is now also used in the client side. So, I'd like to remove "pool".