### PR TITLE
Don't leak exceptions from managed threads

### DIFF
--- a/Network/HTTP2/Arch/Manager.hs
+++ b/Network/HTTP2/Arch/Manager.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | A thread manager.
 --   The manager has responsibility to spawn and kill
@@ -107,9 +108,10 @@ forkManagedUnmask :: Manager -> ((forall x. IO x -> IO x) -> IO ()) -> IO ()
 forkManagedUnmask mgr io =
     void $ mask_ $ forkIOWithUnmask $ \unmask -> do
       addMyId mgr
-      r <- io unmask `onException` deleteMyId mgr
+      -- We catch the exception and do not rethrow it: we don't want the
+      -- exception printed to stderr.
+      io unmask `catch` \(_e :: SomeException) -> return ()
       deleteMyId mgr
-      return r
 
 -- | Adding my thread id to the kill-thread list on stopping.
 --


### PR DESCRIPTION
This PR makes a subtle but useful change to `forkManaged[Unmask]`: instead of using `onException` (which is what `bracket` does), we use `catch`: `onException` will _rethrow_ the exception, but this is not very useful: the only exception handler that sits above the thread is the one installed by default by `forkIOWithUnmask`, which just prints the exception to the terminal. As a result, when the thread manager shuts down managed threads, sometimes those `KilledByHttp2ThreadManager` exceptions were printed to the terminal, interfering with the regular output of the program. (Specifically, I was observing this with [the thread spawned by `forkAndEnqueueWhenReady` in `Arch/Sender.hs`](https://github.com/kazu-yamamoto/http2/blob/6b2d357af9195084f658bc7e2d78a7387c406556/Network/HTTP2/Arch/Sender.hs#L218).)