### PR TITLE
Run with context

### DIFF
--- a/Network/HTTP2/Client/Internal.hs
+++ b/Network/HTTP2/Client/Internal.hs
@@ -1,6 +1,13 @@
 module Network.HTTP2.Client.Internal (
     Request (..),
     Response (..),
+
+    -- * Low level
+    Stream (..),
+    ClientContext (..),
+    runWithContext,
 ) where
 
+import Network.HTTP2.Arch
+import Network.HTTP2.Client.Run
 import Network.HTTP2.Client.Types

--- a/Network/HTTP2/Server/Internal.hs
+++ b/Network/HTTP2/Server/Internal.hs
@@ -2,6 +2,13 @@ module Network.HTTP2.Server.Internal (
     Request (..),
     Response (..),
     Aux (..),
+
+    -- * Low level
+    Stream,
+    ServerContext (..),
+    runWithContext,
 ) where
 
+import Network.HTTP2.Arch
+import Network.HTTP2.Server.Run
 import Network.HTTP2.Server.Types

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -3,26 +3,24 @@
 
 module Network.HTTP2.Server.Run where
 
-import UnliftIO.Async (concurrently_)
-
+import Control.Concurrent.STM
 import Control.Exception
 import Imports
 import Network.HTTP2.Arch
 import Network.HTTP2.Frame
 import Network.HTTP2.Server.Types
 import Network.HTTP2.Server.Worker
+import Network.Socket (SockAddr)
+import UnliftIO.Async (concurrently_)
 
 ----------------------------------------------------------------
 
 -- | Running HTTP/2 server.
 run :: Config -> Server -> IO ()
-run conf@Config{..} server = do
-    ok <- checkPreface
+run conf server = do
+    ok <- checkPreface conf
     when ok $ do
-        serverInfo <- newServerInfo
-        ctx <- newContext serverInfo confBufferSize confMySockAddr confPeerSockAddr
-        -- Workers, worker manager and timer manager
-        mgr <- start confTimeoutManager
+        (ctx, mgr) <- setup conf
         let wc = fromContext ctx
         setAction mgr $ worker wc mgr server
         -- The number of workers is 3.
@@ -31,24 +29,64 @@ run conf@Config{..} server = do
         -- If it is large, huge memory is consumed and many
         -- context switches happen.
         replicateM_ 3 $ spawnAction mgr
-        let runReceiver = frameReceiver ctx conf
-            runSender = frameSender ctx conf mgr
-            runBackgroundThreads = concurrently_ runReceiver runSender
-        stopAfter mgr runBackgroundThreads $ \res -> do
-            closeAllStreams (streamTable ctx) $ either Just (const Nothing) res
-            case res of
-                Left err ->
-                    throwIO err
-                Right x ->
-                    return x
-  where
-    checkPreface = do
-        preface <- confReadN connectionPrefaceLength
-        if connectionPreface /= preface
-            then do
-                goaway conf ProtocolError "Preface mismatch"
-                return False
-            else return True
+        runArch conf ctx mgr
+
+data ServerContext = ServerContext
+    { sctxMySockAddr :: SockAddr
+    , sctxPeerSockAddr :: SockAddr
+    , sctxReadRequest :: IO (Stream, Request)
+    , sctxWriteResponse :: Stream -> Response -> IO ()
+    , sctxWriteBytes :: ByteString -> IO ()
+    }
+
+runWithContext
+    :: Config
+    -> (ServerContext -> IO (IO ()))
+    -> IO ()
+runWithContext conf@Config{..} action = do
+    ok <- checkPreface conf
+    when ok $ do
+        (ctx@Context{..}, mgr) <- setup conf
+        let ServerInfo{..} = toServerInfo roleInfo
+            get = do
+                Input strm inObj <- atomically $ readTQueue inputQ
+                return (strm, Request inObj)
+            putR strm (Response outObj) = do
+                let out = Output strm outObj OObj Nothing (return ())
+                enqueueOutput outputQ out
+            putB bs = enqueueControl controlQ $ CFrames Nothing [bs]
+        io <- action $ ServerContext confMySockAddr confPeerSockAddr get putR putB
+        concurrently_ io $ runArch conf ctx mgr
+
+checkPreface :: Config -> IO Bool
+checkPreface conf@Config{..} = do
+    preface <- confReadN connectionPrefaceLength
+    if connectionPreface /= preface
+        then do
+            goaway conf ProtocolError "Preface mismatch"
+            return False
+        else return True
+
+setup :: Config -> IO (Context, Manager)
+setup Config{..} = do
+    serverInfo <- newServerInfo
+    ctx <- newContext serverInfo confBufferSize confMySockAddr confPeerSockAddr
+    -- Workers, worker manager and timer manager
+    mgr <- start confTimeoutManager
+    return (ctx, mgr)
+
+runArch :: Config -> Context -> Manager -> IO ()
+runArch conf ctx mgr = do
+    let runReceiver = frameReceiver ctx conf
+        runSender = frameSender ctx conf mgr
+        runBackgroundThreads = concurrently_ runReceiver runSender
+    stopAfter mgr runBackgroundThreads $ \res -> do
+        closeAllStreams (streamTable ctx) $ either Just (const Nothing) res
+        case res of
+            Left err ->
+                throwIO err
+            Right x ->
+                return x
 
 -- connClose must not be called here since Run:fork calls it
 goaway :: Config -> ErrorCode -> ByteString -> IO ()


### PR DESCRIPTION
This internal APIs enable to send any kind of HTTP/2 frames.
With this, self-attacking including rapid reset can be implemented.
This ensures that rate controls work well.

Relating to #93.