### PR TITLE
Clean stream termination

### DIFF
--- a/Network/HTTP2/Arch/Context.hs
+++ b/Network/HTTP2/Arch/Context.hs
@@ -4,6 +4,7 @@
 
 module Network.HTTP2.Arch.Context where
 
+import Control.Exception
 import Data.IORef
 import Network.HTTP.Types (Method)
 import Network.Socket (SockAddr)
@@ -191,9 +192,12 @@ halfClosedLocal ctx stream@Stream{streamState} cc = do
 closed :: Context -> Stream -> ClosedCode -> IO ()
 closed ctx@Context{oddStreamTable, evenStreamTable} strm@Stream{streamNumber} cc = do
     if isServerInitiated streamNumber
-        then deleteEven evenStreamTable streamNumber
-        else deleteOdd oddStreamTable streamNumber
+        then deleteEven evenStreamTable streamNumber err
+        else deleteOdd oddStreamTable streamNumber err
     setStreamState ctx strm (Closed cc) -- anyway
+  where
+    err :: SomeException
+    err = toException (closedCodeToError streamNumber cc)
 
 ----------------------------------------------------------------
 -- From peer

--- a/Network/HTTP2/Arch/Receiver.hs
+++ b/Network/HTTP2/Arch/Receiver.hs
@@ -175,14 +175,14 @@ processState (Open _ (NoBody tbl@(_, reqvt))) ctx@Context{..} strm@Stream{stream
                 ProtocolError
                 streamId
                 "no body but content-length is not zero"
-    halfClosedRemote ctx strm
     tlr <- newIORef Nothing
     let inpObj = InpObj tbl (Just 0) (return "") tlr
     if isServer ctx
         then do
             let si = toServerInfo roleInfo
             atomically $ writeTQueue (inputQ si) $ Input strm inpObj
-        else putMVar streamInput inpObj
+        else putMVar streamInput $ Right inpObj
+    halfClosedRemote ctx strm
     return False
 
 -- Transition (process2)
@@ -199,7 +199,7 @@ processState (Open hcl (HasBody tbl@(_, reqvt))) ctx@Context{..} strm@Stream{str
         then do
             let si = toServerInfo roleInfo
             atomically $ writeTQueue (inputQ si) $ Input strm inpObj
-        else putMVar streamInput inpObj
+        else putMVar streamInput $ Right inpObj
     return False
 
 -- Transition (process3)

--- a/test/HTTP2/ClientSpec.hs
+++ b/test/HTTP2/ClientSpec.hs
@@ -37,18 +37,18 @@ spec = do
         it "receives an error if scheme is missing" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "" host' (defaultClient []) `shouldThrow` streamError
+                runClient "" host' (defaultClient []) `shouldThrow` connectionError
 
         it "receives an error if authority is missing" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "http" "" (defaultClient []) `shouldThrow` streamError
+                runClient "http" "" (defaultClient []) `shouldThrow` connectionError
 
         it "receives an error if authority and host are different" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
                 runClient "http" host' (defaultClient [("Host", "foo")])
-                    `shouldThrow` streamError
+                    `shouldThrow` connectionError
 
         it "does not deadlock (in concurrent setting)" $
             E.bracket (forkIO $ runServer irresponsiveServer) killThread $ \_ -> do
@@ -111,6 +111,6 @@ concurrentClient resultVar sendRequest = do
         putMVar resultVar result
     threadDelay 10000
 
-streamError :: Selector HTTP2Error
-streamError (StreamErrorIsReceived _ _) = True
-streamError _ = False
+connectionError :: Selector HTTP2Error
+connectionError ConnectionErrorIsReceived{} = True
+connectionError _ = False

--- a/test/HTTP2/ClientSpec.hs
+++ b/test/HTTP2/ClientSpec.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 module HTTP2.ClientSpec where
 
 import Control.Concurrent
 import qualified Control.Exception as E
+import Control.Monad
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder (byteString)
 import qualified Data.ByteString.Char8 as C8
@@ -12,6 +14,7 @@ import Network.HTTP.Types
 import Network.Run.TCP
 import System.IO.Unsafe (unsafePerformIO)
 import System.Random
+import System.Timeout (timeout)
 import Test.Hspec
 
 import Network.HTTP2.Client
@@ -32,30 +35,48 @@ spec :: Spec
 spec = do
     describe "client" $ do
         it "receives an error if scheme is missing" $
-            E.bracket (forkIO runServer) killThread $ \_ -> do
+            E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "" host' [] `shouldThrow` streamError
+                runClient "" host' (defaultClient []) `shouldThrow` streamError
 
         it "receives an error if authority is missing" $
-            E.bracket (forkIO runServer) killThread $ \_ -> do
+            E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "http" "" [] `shouldThrow` streamError
+                runClient "http" "" (defaultClient []) `shouldThrow` streamError
 
         it "receives an error if authority and host are different" $
-            E.bracket (forkIO runServer) killThread $ \_ -> do
+            E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "http" host' [("Host", "foo")] `shouldThrow` streamError
+                runClient "http" host' (defaultClient [("Host", "foo")])
+                    `shouldThrow` streamError
 
-runServer :: IO ()
-runServer = runTCPServer (Just host) port runHTTP2Server
+        it "does not deadlock (in concurrent setting)" $
+            E.bracket (forkIO $ runServer irresponsiveServer) killThread $ \_ -> do
+                threadDelay 10000
+                resultVar <- newEmptyMVar
+                runClient "http" "localhost" $ concurrentClient resultVar
+                result <- timeout 1000000 $ takeMVar resultVar
+                case result of
+                    Nothing -> expectationFailure "Exception was not raised"
+                    Just (Left ConnectionIsClosed) -> return ()
+                    Just (Left err) -> expectationFailure $ "Raise unexpected exception " ++ show err
+                    Just (Right ()) -> expectationFailure "Unexpected client termination"
+
+runServer :: S.Server -> IO ()
+runServer server = runTCPServer (Just host) port runHTTP2Server
   where
     runHTTP2Server s =
         E.bracket
             (allocSimpleConfig s 4096)
             freeSimpleConfig
             (`S.run` server)
-server :: S.Server
-server _req _aux sendResponse = sendResponse responseHello []
+
+defaultServer :: S.Server
+defaultServer _req _aux sendResponse = sendResponse responseHello []
+
+irresponsiveServer :: S.Server
+irresponsiveServer _req _aux _sendResponse = do
+    forever $ threadDelay 10000000
 
 responseHello :: S.Response
 responseHello = S.responseBuilder ok200 header body
@@ -63,8 +84,8 @@ responseHello = S.responseBuilder ok200 header body
     header = [("Content-Type", "text/plain")]
     body = byteString "Hello, world!\n"
 
-runClient :: Scheme -> Authority -> RequestHeaders -> IO ()
-runClient sc au hd = runTCPClient host port $ runHTTP2Client
+runClient :: Scheme -> Authority -> Client a -> IO a
+runClient sc au client = runTCPClient host port $ runHTTP2Client
   where
     cliconf = defaultClientConfig{scheme = sc, authority = au}
     runHTTP2Client s =
@@ -74,11 +95,21 @@ runClient sc au hd = runTCPClient host port $ runHTTP2Client
             ( \conf -> run cliconf conf $ \sendRequest ->
                 client sendRequest
             )
-    client sendRequest = do
-        let req = requestNoBody methodGet "/" hd
-        sendRequest req $ \rsp -> do
-            responseStatus rsp `shouldBe` Just ok200
-            fmap statusMessage (responseStatus rsp) `shouldBe` Just "OK"
+
+defaultClient :: RequestHeaders -> Client ()
+defaultClient hd sendRequest = do
+    let req = requestNoBody methodGet "/" hd
+    sendRequest req $ \rsp -> do
+        responseStatus rsp `shouldBe` Just ok200
+        fmap statusMessage (responseStatus rsp) `shouldBe` Just "OK"
+
+concurrentClient :: MVar (Either HTTP2Error ()) -> Client ()
+concurrentClient resultVar sendRequest = do
+    let req = requestNoBody methodGet "/" []
+    void $ forkIO $ do
+        result <- E.try $ sendRequest req $ \_rsp -> return ()
+        putMVar resultVar result
+    threadDelay 10000
 
 streamError :: Selector HTTP2Error
 streamError (StreamErrorIsReceived _ _) = True


### PR DESCRIPTION
Prior to this PR, in 

```haskell
Client.run clientConfig config $ \sendRequest -> ..
```

invoking that `sendRequest` callback can result in a `BlockedIndefinitelyOnMVar` exception ("thread blocked indefinitely in an MVar operation") if the connection has already been broken; the immediate cause of this the [call to `takeMVar`](https://github.com/kazu-yamamoto/http2/blob/592ee931b3d4b95ac811cf6a933f300f0741d949/Network/HTTP2/Client/Run.hs#L37) in `Client.Run`

```haskell
rsp <- Response <$> takeMVar (streamInput strm)
```

The key change in this PR is in the definition of `streamInput`:

```haskell
streamInput :: MVar (Either SomeException InpObj)
```

Under normal circumstances we still write a `Right inpObj` to this `MVar`, but when the stream is removed prematurely (in `remove` or in `closeAllStreams`), we write `Left` the reason why the stream was closed; this will then be thrown by the call to `sendRequest`.

@kazu-yamamoto The most important thing I am unsure about is the definition of  `closedCodeToError`, and specifically the distinction between `Finished` and `Killed`, which currently map to the same exception, which doesn't feel quite right. Do you have thoughts on this?

PS. I saw from the git commit log that you are using `fourmolu`  now, but I ran it locally and it made a ton of changes, so I guess you're using a non-standard configuration...? But I couldn't see a config file in the repo, did I miss it..?

