### PR TITLE
Use `String` for `Authority`

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -14,11 +14,13 @@ import Network.Socket (SockAddr)
 import UnliftIO.Async
 import UnliftIO.Concurrent
 import UnliftIO.STM
+import qualified Data.ByteString.UTF8 as UTF8
 
 import Imports
 import Network.HTTP2.Client.Types
 import Network.HTTP2.Frame
 import Network.HTTP2.H2
+import Network.HTTP.Types (Header)
 
 -- | Client configuration
 data ClientConfig = ClientConfig
@@ -172,11 +174,12 @@ sendRequest ctx@Context{..} mgr scheme auth (Request req) = do
             -- Otherwise, it would be re-enqueue because of empty
             -- resulting in out-of-order.
             -- To implement this, 'tbqNonEmpty' is used.
-            let hdr1
+            let hdr1, hdr2 :: [Header]
+                hdr1
                     | scheme /= "" = (":scheme", scheme) : hdr0
                     | otherwise = hdr0
                 hdr2
-                    | auth /= "" = (":authority", auth) : hdr1
+                    | auth /= "" = (":authority", UTF8.fromString auth) : hdr1
                     | otherwise = hdr1
                 req' = req{outObjHeaders = hdr2}
             -- FLOW CONTROL: SETTINGS_MAX_CONCURRENT_STREAMS: send: respecting peer's limit

--- a/Network/HTTP2/H2/Context.hs
+++ b/Network/HTTP2/H2/Context.hs
@@ -32,7 +32,7 @@ data ServerInfo = ServerInfo
 
 data ClientInfo = ClientInfo
     { scheme :: ByteString
-    , authority :: ByteString
+    , authority :: Authority
     }
 
 toServerInfo :: RoleInfo -> ServerInfo
@@ -46,7 +46,7 @@ toClientInfo _ = error "toClientInfo"
 newServerInfo :: IO RoleInfo
 newServerInfo = RIS . ServerInfo <$> newTQueueIO
 
-newClientInfo :: ByteString -> ByteString -> RoleInfo
+newClientInfo :: ByteString -> Authority -> RoleInfo
 newClientInfo scm auth = RIC $ ClientInfo scm auth
 
 ----------------------------------------------------------------

--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -15,6 +15,7 @@ import Network.Control
 import UnliftIO.Concurrent
 import qualified UnliftIO.Exception as E
 import UnliftIO.STM
+import qualified Data.ByteString.UTF8 as UTF8
 
 import Imports hiding (delete, insert)
 import Network.HPACK
@@ -365,7 +366,7 @@ push header@FrameHeader{streamId} bs ctx = do
     (_, vt) <- hpackDecodeHeader frag streamId ctx
     let ClientInfo{..} = toClientInfo $ roleInfo ctx
     when
-        ( getHeaderValue tokenAuthority vt == Just authority
+        ( getHeaderValue tokenAuthority vt == Just (UTF8.fromString authority)
             && getHeaderValue tokenScheme vt == Just scheme
         )
         $ do

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -28,7 +28,7 @@ import Network.HTTP2.H2.File
 type Scheme = ByteString
 
 -- | Authority.
-type Authority = ByteString
+type Authority = String
 
 -- | Path.
 type Path = ByteString

--- a/Network/HTTP2/Server.hs
+++ b/Network/HTTP2/Server.hs
@@ -118,6 +118,7 @@ module Network.HTTP2.Server (
 import Data.ByteString.Builder (Builder)
 import Data.IORef (readIORef)
 import qualified Network.HTTP.Types as H
+import qualified Data.ByteString.UTF8 as UTF8
 
 import Imports
 import Network.HPACK
@@ -147,7 +148,7 @@ requestPath (Request req) = getHeaderValue tokenPath vt
 
 -- | Getting the authority from a request.
 requestAuthority :: Request -> Maybe Authority
-requestAuthority (Request req) = getHeaderValue tokenAuthority vt
+requestAuthority (Request req) = UTF8.toString <$> getHeaderValue tokenAuthority vt
   where
     (_, vt) = inpObjHeaders req
 

--- a/http2.cabal
+++ b/http2.cabal
@@ -127,7 +127,8 @@ library
         network-control >= 0.0.2 && < 0.1,
         unix-time >= 0.4.11 && < 0.5,
         time-manager >= 0.0.1 && < 0.1,
-        unliftio >= 0.2 && < 0.3
+        unliftio >= 0.2 && < 0.3,
+        utf8-string >= 1.0 && < 1.1
 
 executable client
     main-is:            client.hs

--- a/test/HTTP2/ClientSpec.hs
+++ b/test/HTTP2/ClientSpec.hs
@@ -8,9 +8,7 @@ module HTTP2.ClientSpec where
 import Control.Concurrent
 import qualified Control.Exception as E
 import Control.Monad
-import Data.ByteString (ByteString)
 import Data.ByteString.Builder (byteString)
-import qualified Data.ByteString.Char8 as C8
 import Data.Foldable (for_)
 import Data.Maybe
 import Data.Traversable (for)
@@ -32,16 +30,13 @@ port = show $ unsafePerformIO (randomPort <$> getStdGen)
 host :: String
 host = "127.0.0.1"
 
-host' :: ByteString
-host' = C8.pack host
-
 spec :: Spec
 spec = do
     describe "client" $ do
         it "receives an error if scheme is missing" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "" host' (defaultClient []) `shouldThrow` connectionError
+                runClient "" host (defaultClient []) `shouldThrow` connectionError
 
         it "receives an error if authority is missing" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
@@ -51,7 +46,7 @@ spec = do
         it "receives an error if authority and host are different" $
             E.bracket (forkIO $ runServer defaultServer) killThread $ \_ -> do
                 threadDelay 10000
-                runClient "http" host' (defaultClient [("Host", "foo")])
+                runClient "http" host (defaultClient [("Host", "foo")])
                     `shouldThrow` connectionError
 
         it "does not deadlock (in concurrent setting)" $

--- a/test/HTTP2/ServerSpec.hs
+++ b/test/HTTP2/ServerSpec.hs
@@ -177,7 +177,7 @@ runClient :: (Socket -> BufferSize -> IO Config) -> IO ()
 runClient allocConfig =
     runTCPClient host port $ runHTTP2Client
   where
-    auth = C8.pack host
+    auth = host
     cliconf = C.defaultClientConfig{C.authority = auth}
     runHTTP2Client s =
         E.bracket
@@ -315,7 +315,7 @@ runAttack :: (C.ClientIO -> IO ()) -> IO ()
 runAttack attack =
     runTCPClient host port $ runHTTP2Client
   where
-    auth = C8.pack host
+    auth = host
     cliconf = C.defaultClientConfig{C.authority = auth}
     runHTTP2Client s =
         E.bracket


### PR DESCRIPTION
This makes encoding to and from UTF8 (as per
https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) the responsibility of the library rather than the client.