### PR TITLE
Deal with `RST_STREAM` in `HalfClosedLocal` state

### DIFF
--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -557,6 +557,7 @@ stream FrameRSTStream header@FrameHeader{streamId} bs ctx s strm = do
             ConnectionErrorIsSent EnhanceYourCalm streamId "too many rst_stream"
     RSTStreamFrame err <- guardIt $ decodeRSTStreamFrame header bs
     let cc = Reset err
+    closed ctx strm cc
 
     -- HTTP2 spec, section 5.1, "Stream States":
     --
@@ -582,7 +583,6 @@ stream FrameRSTStream header@FrameHeader{streamId} bs ctx s strm = do
         (HalfClosedRemote, NoError) ->
             return (Closed cc)
         _otherwise -> do
-            closed ctx strm cc
             E.throwIO $ StreamErrorIsReceived err streamId
 
 -- (No state transition)


### PR DESCRIPTION
See detailed justification in the code itself.

@kazu-yamamoto , just FYI, I'm getting closer to a first release of `grapesy`, my new gRPC library that has motivated all of my PRs against `http2` and `http2-tls`. Its own test-suite is still not 100% happy, I don't yet know if that will yield further PRs, but `grapesy` now passes the full official gRPC interop test suite against both the Python reference and (after this PR fixing a `RST_STREAM` problem), also against the C++ reference. There are a few more references to check, I have to deal with my own test suite failures, and then I still have to do some stress testing to see if there are any memory leaks, but we are getting closer to a stable product.