### PR TITLE
Make ping rate limit configurable

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -66,6 +66,7 @@ module Network.HTTP2.Client (
     initialWindowSize,
     maxFrameSize,
     maxHeaderListSize,
+    pingRateLimit,
 
     -- * Common configuration
     Config (..),

--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -52,7 +52,7 @@ data ClientConfig = ClientConfig
 -- @userinfo\@@ as part of the authority.
 --
 -- >>> defaultClientConfig
--- ClientConfig {scheme = "http", authority = "localhost", cacheLimit = 64, connectionWindowSize = 1048576, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing}}
+-- ClientConfig {scheme = "http", authority = "localhost", cacheLimit = 64, connectionWindowSize = 1048576, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10}}
 defaultClientConfig :: ClientConfig
 defaultClientConfig =
     ClientConfig

--- a/Network/HTTP2/H2/Settings.hs
+++ b/Network/HTTP2/H2/Settings.hs
@@ -25,13 +25,15 @@ data Settings = Settings
     -- ^ SETTINGS_MAX_FRAME_SIZE
     , maxHeaderListSize :: Maybe Int
     -- ^ SETTINGS_MAX_HEADER_LIST_SIZE
+    , pingRateLimit :: Int
+    -- ^ Maximum number of pings allowed per second (CVE-2019-9512)
     }
     deriving (Eq, Show)
 
 -- | The default settings.
 --
 -- >>> baseSettings
--- Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Nothing, initialWindowSize = 65535, maxFrameSize = 16384, maxHeaderListSize = Nothing}
+-- Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Nothing, initialWindowSize = 65535, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10}
 baseSettings :: Settings
 baseSettings =
     Settings
@@ -41,12 +43,13 @@ baseSettings =
         , initialWindowSize = defaultWindowSize -- 64K (65,535)
         , maxFrameSize = defaultPayloadLength -- 2^14 (16,384)
         , maxHeaderListSize = Nothing
+        , pingRateLimit = 10
         }
 
 -- | The default settings.
 --
 -- >>> defaultSettings
--- Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing}
+-- Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10}
 defaultSettings :: Settings
 defaultSettings =
     baseSettings
@@ -59,7 +62,7 @@ defaultSettings =
 -- | Updating settings.
 --
 -- >>> fromSettingsList defaultSettings [(SettingsEnablePush,0),(SettingsMaxHeaderListSize,200)]
--- Settings {headerTableSize = 4096, enablePush = False, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Just 200}
+-- Settings {headerTableSize = 4096, enablePush = False, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Just 200, pingRateLimit = 10}
 {- FOURMOLU_DISABLE -}
 fromSettingsList :: Settings -> SettingsList -> Settings
 fromSettingsList settings kvs = foldl' update settings kvs

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -30,7 +30,7 @@ data ServerConfig = ServerConfig
 -- | The default server config.
 --
 -- >>> defaultServerConfig
--- ServerConfig {numberOfWorkers = 8, connectionWindowSize = 1048576, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing}}
+-- ServerConfig {numberOfWorkers = 8, connectionWindowSize = 1048576, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10}}
 defaultServerConfig :: ServerConfig
 defaultServerConfig =
     ServerConfig

--- a/test/HTTP2/ServerSpec.hs
+++ b/test/HTTP2/ServerSpec.hs
@@ -345,15 +345,7 @@ rapidPing C.ClientIO{..} = do
     let einfo = EncodeInfo defaultFlags 0 Nothing
         opaque64 = "01234567"
         bs = encodeFrame einfo $ PingFrame opaque64
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
-    cioWriteBytes bs
+    replicateM_ 20 $ cioWriteBytes bs
 
 rapidEmptyHeader :: C.ClientIO -> IO ()
 rapidEmptyHeader C.ClientIO{..} = do


### PR DESCRIPTION
I'm dealing with some gRPC servers (written in golang) that routine exceed the limit of 4 pings/sec (increasing the limit to 10 seems to do the trick). This PR makes the ping rate limit configurable.