### PR TITLE
 A new type synonym 

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -75,6 +75,7 @@ module Network.HTTP2.Client (
 
     -- * HTTP\/2 client
     Client,
+    SendRequest,
 
     -- * Request
     Request,

--- a/Network/HTTP2/Client/Types.hs
+++ b/Network/HTTP2/Client/Types.hs
@@ -6,8 +6,11 @@ import Network.HTTP2.H2
 
 ----------------------------------------------------------------
 
+-- | Send a request and receive its response.
+type SendRequest = forall r. Request -> (Response -> IO r) -> IO r
+
 -- | Client type.
-type Client a = (forall b. Request -> (Response -> IO b) -> IO b) -> Aux -> IO a
+type Client a = SendRequest -> Aux -> IO a
 
 -- | Request from client.
 newtype Request = Request OutObj deriving (Show)


### PR DESCRIPTION
This new type synonym would make other packages more readable, which depends on `http2`.
