### PR TITLE
Use time-manager >= 0.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 5.2.1
+
+* Using time-manager v0.1.0.
+  [#115](https://github.com/kazu-yamamoto/http2/pull/115)
+
 ## 5.2.0
 
 * Using http-semantics

--- a/http2.cabal
+++ b/http2.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               http2
-version:            5.2.0
+version:            5.2.1
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
@@ -121,7 +121,7 @@ library
         network-byte-order >=0.1.7 && <0.2,
         network-control >=0.1 && <0.2,
         stm >=2.5 && <2.6,
-        time-manager >=0.0.1 && <0.1,
+        time-manager >=0.1 && <0.2,
         unix-time >=0.4.11 && <0.5,
         unliftio >=0.2 && <0.3,
         utf8-string >=1.0 && <1.1


### PR DESCRIPTION
The new time-manager API removes `Handle`s immediately upon `cancel`, rather than relying on a timeout to occur. This effects http2 since servers processing many streams with a very long timeout will no longer accumulate `Handle`s, as the `Handle`s will be removed immediately when the stream is closed.

This PR bumps the time-manager dependency to include these changes and bumps the http2 version to 5.2.1.