### PR TITLE
Don't wait for `push` before sending headers

### DIFF
--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -620,7 +620,9 @@ data Source
         (IORef Bool)
 
 mkSource
-    :: TQueue (Either E.SomeException (ByteString, Bool)) -> (Int -> IO ()) -> IO Source
+    :: TQueue (Either E.SomeException (ByteString, Bool))
+    -> (Int -> IO ())
+    -> IO Source
 mkSource q inform = Source inform q <$> newIORef "" <*> newIORef False
 
 readSource :: Source -> IO (ByteString, Bool)

--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -180,6 +180,7 @@ frameSender
             -- the stream from stream table.
             when endOfStream $ halfClosedLocal ctx strm Finished
             off <- flushIfNecessary off'
+            let setOutputType otyp = out{outputType = otyp}
             case body of
                 OutBodyNone -> return off
                 OutBodyFile (FileSpec path fileoff bytecount) -> do
@@ -188,17 +189,17 @@ frameSender
                         Closer closer -> timeoutClose mgr closer
                         Refresher refresher -> return refresher
                     let next = fillFileBodyGetNext pread fileoff bytecount refresh
-                        out' = out{outputType = ONext next tlrmkr}
+                        out' = setOutputType $ ONext next tlrmkr
                     output out' off lim
                 OutBodyBuilder builder -> do
                     let next = fillBuilderBodyGetNext builder
-                        out' = out{outputType = ONext next tlrmkr}
+                        out' = setOutputType $ ONext next tlrmkr
                     output out' off lim
                 OutBodyStreaming _ -> do
-                    let out' = out{outputType = nextForStreaming mtbq tlrmkr}
+                    let out' = setOutputType $ nextForStreaming mtbq tlrmkr
                     output out' off lim
                 OutBodyStreamingUnmask _ -> do
-                    let out' = out{outputType = nextForStreaming mtbq tlrmkr}
+                    let out' = setOutputType $ nextForStreaming mtbq tlrmkr
                     output out' off lim
         output out@(Output strm _ (OPush ths pid) _ _) off0 lim = do
             -- Creating a push promise header

--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -168,7 +168,7 @@ frameSender
                 sentinel
                 out
                 reqflush
-        output out@(Output strm (OutObj hdr body tlrmkr) OObj mtbq _) off0 lim = do
+        output (Output strm obj@(OutObj hdr body tlrmkr) OObj mtbq sentinel) off0 lim = do
             -- Header frame and Continuation frame
             let sid = streamNumber strm
                 endOfStream = case body of
@@ -180,7 +180,7 @@ frameSender
             -- the stream from stream table.
             when endOfStream $ halfClosedLocal ctx strm Finished
             off <- flushIfNecessary off'
-            let setOutputType otyp = out{outputType = otyp}
+            let setOutputType otyp = Output strm obj otyp mtbq sentinel
             case body of
                 OutBodyNone -> return off
                 OutBodyFile (FileSpec path fileoff bytecount) -> do


### PR DESCRIPTION
In https://github.com/kazu-yamamoto/http2/commit/a76cdf3 a change was introduced which meant that a streaming request was not enqueued until at least some data was available.  The reason (I think) was that without that delay, `outputOrEnqueueAgain` would check the queue and the streaming window, realize that the queue was empty, and then re-enqueue the `Output`, causing it to be handled out-of-order (which is problematic, because streams [must be opened in order](https://datatracker.ietf.org/doc/html/rfc7540#section-5.1.1)). 

We can't simply change `outputOrEnqueueAgain` _not_ to check the queue, because if there are no output available, we should indeed process other streams first. However, we _can_ add a special case to `outputOrEnqueueAgain` so that it _doesn't_ check either whether data is available _or_ the streaming window in the case of an `OObj` object (which will initialize the stream by sending the request headers). This is sound, because the headers do not depend on the initial data (they are fully known at this point), and the streaming window only applies to `DATA` frames. 

Once we do this, we can enqueue the request before any data is available, which can be important for some applications where the request headers must be sent even if no data is available. This PR does this in 6 steps: steps 1-4 don't change the semantics at all, but do some step-by-step refactoring to make the next two changes easier to follow; step 5 makes the change to `outputOrEnqueueAgain`, and step 6 finally changes `sendStreaming` not to wait for data to become available.

Side note: I was previously working around this by calling `push` with an empty string, but this causes problems of its own. Indeed, I hope to be following up to this PR with a second PR that makes further changes; that second PR does perhaps not _rely_ on this one, but this PR _does_ make that second PR much easier to verify, I think. That second PR is not yet ready, but submitting this one already in case I'm doing something here that is completely broken. 