### PR TITLE
Update http-semantics dependency, ver bump up

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 5.2.6
+
+* Update for latest http-semantics
+  [#122](https://github.com/kazu-yamamoto/http2/pull/124)
+
 ## 5.2.5
 
 * Setting peer initial window size properly.

--- a/http2.cabal
+++ b/http2.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               http2
-version:            5.2.5
+version:            5.2.6
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
@@ -115,7 +115,7 @@ library
         bytestring >=0.10,
         case-insensitive >=1.2 && <1.3,
         containers >=0.6,
-        http-semantics >= 0.1.1 && <0.2,
+        http-semantics >= 0.1.2 && <0.2,
         http-types >=0.12 && <0.13,
         network >=3.1,
         network-byte-order >=0.1.7 && <0.2,


### PR DESCRIPTION
Another http2 version including the [latest patch from http-semantics](https://github.com/kazu-yamamoto/http-semantics/pull/4)! Thank you in advance.