### PR TITLE
Recover rxflow on closing

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -85,7 +85,9 @@ run cconf@ClientConfig{..} conf client = do
     clientCore ctx mgr req processResponse = do
         strm <- sendRequest ctx mgr scheme authority req
         rsp <- getResponse strm
-        processResponse rsp
+        x <- processResponse rsp
+        adjustRxWindow (rxFlow ctx) strm
+        return x
     runClient ctx mgr = do
         x <- client (clientCore ctx mgr) $ aux ctx
         waitCounter0 mgr
@@ -205,14 +207,15 @@ sendStreaming Context{..} mgr req sid newstrm strmbdy = do
     forkManagedUnmask mgr $ \unmask -> do
         decrementedCounter <- newIORef False
         let decCounterOnce = do
-              alreadyDecremented <- atomicModifyIORef decrementedCounter $ \b -> (True, b)
-              unless alreadyDecremented $ decCounter mgr
-        let iface = OutBodyIface {
-                outBodyUnmask = unmask
-              , outBodyPush = \b -> atomically $ writeTBQueue tbq (StreamingBuilder b Nothing)
-              , outBodyPushFinal = \b -> atomically $ writeTBQueue tbq (StreamingBuilder b (Just decCounterOnce))
-              , outBodyFlush = atomically $ writeTBQueue tbq StreamingFlush
-              }
+                alreadyDecremented <- atomicModifyIORef decrementedCounter $ \b -> (True, b)
+                unless alreadyDecremented $ decCounter mgr
+        let iface =
+                OutBodyIface
+                    { outBodyUnmask = unmask
+                    , outBodyPush = \b -> atomically $ writeTBQueue tbq (StreamingBuilder b Nothing)
+                    , outBodyPushFinal = \b -> atomically $ writeTBQueue tbq (StreamingBuilder b (Just decCounterOnce))
+                    , outBodyFlush = atomically $ writeTBQueue tbq StreamingFlush
+                    }
             finished = atomically $ writeTBQueue tbq $ StreamingFinished decCounterOnce
         incCounter mgr
         strmbdy iface `finally` finished

--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -612,17 +612,9 @@ stream x FrameHeader{streamId} _ _ _ _ =
 ----------------------------------------------------------------
 
 -- | Type for input streaming.
-data Source
-    = Source
-        (Int -> IO ())
-        (TQueue (Either E.SomeException (ByteString, Bool)))
-        (IORef ByteString)
-        (IORef Bool)
+data Source = Source (Int -> IO ()) RxQ (IORef ByteString) (IORef Bool)
 
-mkSource
-    :: TQueue (Either E.SomeException (ByteString, Bool))
-    -> (Int -> IO ())
-    -> IO Source
+mkSource :: RxQ -> (Int -> IO ()) -> IO Source
 mkSource q inform = Source inform q <$> newIORef "" <*> newIORef False
 
 readSource :: Source -> IO (ByteString, Bool)

--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -190,11 +190,12 @@ processState (Open _ (NoBody tbl@(_, reqvt))) ctx@Context{..} strm@Stream{stream
     return False
 
 -- Transition (process2)
-processState (Open hcl (HasBody tbl@(_, reqvt))) ctx@Context{..} strm@Stream{streamInput} _streamId = do
+processState (Open hcl (HasBody tbl@(_, reqvt))) ctx@Context{..} strm@Stream{streamInput, streamRxQ} _streamId = do
     let mcl = fst <$> (getFieldValue tokenContentLength reqvt >>= C8.readInt)
     bodyLength <- newIORef 0
     tlr <- newIORef Nothing
     q <- newTQueueIO
+    writeIORef streamRxQ $ Just q
     setStreamState ctx strm $ Open hcl (Body q mcl bodyLength tlr)
     -- FLOW CONTROL: WINDOW_UPDATE 0: recv: announcing my limit properly
     -- FLOW CONTROL: WINDOW_UPDATE: recv: announcing my limit properly

--- a/Network/HTTP2/H2/Stream.hs
+++ b/Network/HTTP2/H2/Stream.hs
@@ -52,6 +52,7 @@ newOddStream sid txwin rxwin =
         <*> newEmptyMVar
         <*> newTVarIO (newTxFlow txwin)
         <*> newIORef (newRxFlow rxwin)
+        <*> newIORef Nothing
 
 newEvenStream :: StreamId -> WindowSize -> WindowSize -> IO Stream
 newEvenStream sid txwin rxwin =
@@ -60,6 +61,7 @@ newEvenStream sid txwin rxwin =
         <*> newEmptyMVar
         <*> newTVarIO (newTxFlow txwin)
         <*> newIORef (newRxFlow rxwin)
+        <*> newIORef Nothing
 
 ----------------------------------------------------------------
 

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -157,6 +157,7 @@ data Stream = Stream
     , streamInput :: MVar (Either SomeException InpObj) -- Client only
     , streamTxFlow :: TVar TxFlow
     , streamRxFlow :: IORef RxFlow
+    , streamRxQ :: IORef (Maybe RxQ)
     }
 
 instance Show Stream where

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -149,6 +149,8 @@ instance Show StreamState where
 
 ----------------------------------------------------------------
 
+type RxQ = TQueue (Either E.SomeException (ByteString, Bool))
+
 data Stream = Stream
     { streamNumber :: StreamId
     , streamState :: IORef StreamState


### PR DESCRIPTION
This should fix https://github.com/kazu-yamamoto/http-semantics/pull/5.

@FinleyMcIlwaine Could you test this branch?
`getResponseBodyChunk` should not be necessary anymore.