### PR TITLE
Fix treatment of async exceptions

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -71,7 +71,6 @@ module Network.HTTP2.Client (
     emptyFrameRateLimit,
     rstRateLimit,
 
-
     -- * Common configuration
     Config (..),
     allocSimpleConfig,


### PR DESCRIPTION
In https://github.com/kazu-yamamoto/http2/pull/92 we added an exception handler that was meant to catch _all_ exceptions (sync and async). This got changed in https://github.com/kazu-yamamoto/http2/pull/114 (specifically, https://github.com/kazu-yamamoto/http2/pull/114/commits/52a9619ba95b67d469205cb0dea546ada8489baa): when we moved from `Control.Exception` to `UnliftIO.Exception`, we got a different behaviour for `catch` and friends (see https://github.com/well-typed/grapesy/issues/193#issuecomment-2238704595) for a full list. This commit fixes some unintended consequences of this change.

I tried to do an exhaustive check of all uses of these functions in `http2`, I'll post a full report separately.

