### PR TITLE
Support stream cancellation

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -236,7 +236,7 @@ sendStreaming
     -> IO (TBQueue StreamingChunk)
 sendStreaming Context{..} strm strmbdy = do
     tbq <- newTBQueueIO 10 -- fixme: hard coding: 10
-    finishedOrCancelled <- newIORef False
+    finishedOrCancelled <- newTVarIO False
     let label = "H2 streaming supporter for stream " ++ show (streamNumber strm)
     forkManagedUnmask threadManager label $ \unmask -> do
         let iface =
@@ -244,21 +244,22 @@ sendStreaming Context{..} strm strmbdy = do
                     { outBodyUnmask = unmask
                     , outBodyPush = \b -> atomically $ writeTBQueue tbq $ StreamingBuilder b NotEndOfStream
                     , outBodyPushFinal = \b -> do
-                        atomicWriteIORef finishedOrCancelled True
-                        atomically $ writeTBQueue tbq $ StreamingBuilder b (EndOfStream Nothing)
-                        atomically $ writeTBQueue tbq $ StreamingFinished Nothing
+                        atomically $ do
+                          writeTVar finishedOrCancelled True
+                          writeTBQueue tbq $ StreamingBuilder b (EndOfStream Nothing)
+                          writeTBQueue tbq $ StreamingFinished Nothing
                     , outBodyFlush = atomically $ writeTBQueue tbq StreamingFlush
-                    , outBodyCancel = \mErr -> do
-                        already <- atomicModifyIORef finishedOrCancelled (\x -> (True, x))
-                        if already then do
-                          return ()
-                        else
-                          atomically $ writeTBQueue tbq (StreamingCancelled mErr)
+                    , outBodyCancel = \mErr -> atomically $ do
+                        already <- readTVar finishedOrCancelled
+                        writeTVar finishedOrCancelled True
+                        unless already $
+                          writeTBQueue tbq (StreamingCancelled mErr)
                     }
-            finished = do
-              already <- atomicModifyIORef finishedOrCancelled (\x -> (True, x))
+            finished = atomically $ do
+              already <- readTVar finishedOrCancelled
+              writeTVar finishedOrCancelled True
               unless already $
-                atomically $ writeTBQueue tbq $ StreamingFinished Nothing
+                writeTBQueue tbq $ StreamingFinished Nothing
         strmbdy iface `finally` finished
     return tbq
 

--- a/Network/HTTP2/H2/Context.hs
+++ b/Network/HTTP2/H2/Context.hs
@@ -72,6 +72,9 @@ data Context = Context
     , myStreamId :: TVar StreamId
     , peerStreamId :: IORef StreamId
     , outputBufferLimit :: IORef Int
+
+      -- | Invariant: Each stream will only ever have at most one 'Output'
+      -- object in this queue at any moment.
     , outputQ :: TQueue Output
     , outputQStreamID :: TVar StreamId
     , controlQ :: TQueue Control

--- a/Network/HTTP2/H2/Stream.hs
+++ b/Network/HTTP2/H2/Stream.hs
@@ -50,7 +50,6 @@ newOddStream sid txwin rxwin =
     Stream sid
         <$> newIORef Idle
         <*> newEmptyMVar
-        <*> newEmptyMVar
         <*> newTVarIO (newTxFlow txwin)
         <*> newIORef (newRxFlow rxwin)
         <*> newIORef Nothing
@@ -59,7 +58,6 @@ newEvenStream :: StreamId -> WindowSize -> WindowSize -> IO Stream
 newEvenStream sid txwin rxwin =
     Stream sid
         <$> newIORef Reserved
-        <*> newEmptyMVar
         <*> newEmptyMVar
         <*> newTVarIO (newTxFlow txwin)
         <*> newIORef (newRxFlow rxwin)
@@ -84,7 +82,6 @@ closeAllStreams ovar evar mErr' = do
     finalize strm = do
         st <- readStreamState strm
         void $ tryPutMVar (streamInput strm) err
-        void $ tryPutMVar (streamHeadersSent strm) err
         case st of
             Open _ (Body q _ _ _) ->
                 atomically $ writeTQueue q $ maybe (Right (mempty, True)) Left mErr

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -214,7 +214,6 @@ data HTTP2Error
     | StreamErrorIsSent ErrorCode StreamId ReasonPhrase
     | BadThingHappen E.SomeException
     | GoAwayIsSent
-    | RSTStreamIsSent
     deriving (Show, Typeable)
 
 instance E.Exception HTTP2Error

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -160,7 +160,6 @@ type RxQ = TQueue (Either E.SomeException (ByteString, Bool))
 data Stream = Stream
     { streamNumber :: StreamId
     , streamState :: IORef StreamState
-    , streamHeadersSent :: MVar (Either SomeException ()) -- Client only
     , streamInput :: MVar (Either SomeException InpObj) -- Client only
     , streamTxFlow :: TVar TxFlow
     , streamRxFlow :: IORef RxFlow


### PR DESCRIPTION
We now support stream cancellation via the `OutBodyIface` API's `outBodyCancel` function. Some care was taken to ensure that cancelling idle streams does not result in protocol errors. In particular, `outBodyCancel` will wait until either the headers have been sent successfully or an exception occurs. If we aren't totally sure that the headers are sent, we won't send `RST_STREAM`.