### PR TITLE
enclosing IPv6 literal authority with square brackets

### DIFF
--- a/http2.cabal
+++ b/http2.cabal
@@ -118,6 +118,7 @@ library
         containers >=0.6,
         http-semantics >= 0.2 && <0.3,
         http-types >=0.12 && <0.13,
+        iproute >= 1.7 && < 1.8,
         network >=3.1,
         network-byte-order >=0.1.7 && <0.2,
         network-control >=0.1 && <0.2,


### PR DESCRIPTION
https://github.com/kazu-yamamoto/dnsext/issues/186 revealed that square brackets are necessary for IPv6 literal in `:authority`.

For more information, please refer to:
https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2