### PR TITLE
Avoid `undefined` in client

### DIFF
--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -58,6 +58,9 @@ frameReceiver ctx@Context{..} conf@Config{..} = do
                 loop
 
     sendGoaway se
+        | Just GoAwayIsSent <- E.fromException se = do
+            waitCounter0 threadManager
+            enqueueControl controlQ $ CFinish GoAwayIsSent
         | Just ConnectionIsClosed <- E.fromException se = do
             waitCounter0 threadManager
             enqueueControl controlQ $ CFinish ConnectionIsClosed


### PR DESCRIPTION
Instead of `race`ing the background threads and the client, we run them concurrently and check which finishes first. If the background threads finished first, we `wait` for the client. If the client finished first, we `cancel` the background threads and return.

@kazu-yamamoto we also added a case in `sendGoAway` in `Network.HTTP2.H2.Receiver` so that `GoAwayIsSent` is handled the same as `ConnectionIsClosed`, which appears to more closely match the behavior of the frame sender. Also, previously if `GoAwayIsSent` happened, it would be wrapped in a `BadThingHappen` which would cause the frame sender to rethrow it. Does this change seem acceptable to you?

Also, this does not communicate the stream id from a `GOAWAY` to the client if the background threads finish first, but feel free to extend this PR to add that!