### PR TITLE
Remove `numberOfWorkers`

### DIFF
--- a/Network/HTTP2/Server.hs
+++ b/Network/HTTP2/Server.hs
@@ -32,7 +32,6 @@ module Network.HTTP2.Server (
     -- * Server configuration
     ServerConfig,
     defaultServerConfig,
-    numberOfWorkers,
     connectionWindowSize,
     settings,
 

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -19,9 +19,7 @@ import Network.HTTP2.Server.Worker
 
 -- | Server configuration
 data ServerConfig = ServerConfig
-    { numberOfWorkers :: Int
-    -- ^ The number of workers
-    , connectionWindowSize :: WindowSize
+    { connectionWindowSize :: WindowSize
     -- ^ The window size of incoming streams
     , settings :: Settings
     -- ^ Settings
@@ -31,12 +29,11 @@ data ServerConfig = ServerConfig
 -- | The default server config.
 --
 -- >>> defaultServerConfig
--- ServerConfig {numberOfWorkers = 8, connectionWindowSize = 16777216, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10, emptyFrameRateLimit = 4, settingsRateLimit = 4, rstRateLimit = 4}}
+-- ServerConfig {connectionWindowSize = 16777216, settings = Settings {headerTableSize = 4096, enablePush = True, maxConcurrentStreams = Just 64, initialWindowSize = 262144, maxFrameSize = 16384, maxHeaderListSize = Nothing, pingRateLimit = 10, emptyFrameRateLimit = 4, settingsRateLimit = 4, rstRateLimit = 4}}
 defaultServerConfig :: ServerConfig
 defaultServerConfig =
     ServerConfig
-        { numberOfWorkers = 8
-        , connectionWindowSize = defaultMaxData
+        { connectionWindowSize = defaultMaxData
         , settings = defaultSettings
         }
 


### PR DESCRIPTION
With the new `http2` architecture, workers are no longer pooled. The `numberOfWorkers` server config field is therefore no longer necessary.

Corresponding `http2-tls` PR: https://github.com/kazu-yamamoto/http2-tls/pull/21