### PR TITLE
Simple sync

### DIFF
--- a/Network/HTTP2/Client/Run.hs
+++ b/Network/HTTP2/Client/Run.hs
@@ -84,7 +84,10 @@ run cconf@ClientConfig{..} conf client = do
             { auxPossibleClientStreams = possibleClientStream ctx
             }
     clientCore ctx req processResponse = do
-        strm <- sendRequest conf ctx scheme authority req
+        (strm, moutobj) <- makeStream ctx scheme authority req
+        case moutobj of
+            Nothing -> return ()
+            Just outobj -> sendRequest conf ctx strm outobj
         rsp <- getResponse strm
         x <- processResponse rsp
         adjustRxWindow ctx strm
@@ -109,7 +112,10 @@ runIO cconf@ClientConfig{..} conf@Config{..} action = do
     ctx@Context{..} <- setup cconf conf
     let putB bs = enqueueControl controlQ $ CFrames Nothing [bs]
         putR req = do
-            strm <- sendRequest conf ctx scheme authority req
+            (strm, moutobj) <- makeStream ctx scheme authority req
+            case moutobj of
+                Nothing -> return ()
+                Just outobj -> sendRequest conf ctx strm outobj
             return (streamNumber strm, strm)
         get = getResponse
         create = openOddStreamWait ctx
@@ -165,23 +171,22 @@ runH2 conf ctx runClient = do
                     Left () -> do
                         wait runningClient
 
-sendRequest
-    :: Config
-    -> Context
+makeStream
+    :: Context
     -> Scheme
     -> Authority
     -> Request
-    -> IO Stream
-sendRequest conf ctx@Context{..} scheme auth (Request req) = do
+    -> IO (Stream, Maybe OutObj)
+makeStream ctx@Context{..} scheme auth (Request req) = do
     -- Checking push promises
     let hdr0 = outObjHeaders req
-        method = fromMaybe (error "sendRequest:method") $ lookup ":method" hdr0
-        path = fromMaybe (error "sendRequest:path") $ lookup ":path" hdr0
+        method = fromMaybe (error "makeStream:method") $ lookup ":method" hdr0
+        path = fromMaybe (error "makeStream:path") $ lookup ":path" hdr0
     mstrm0 <- lookupEvenCache evenStreamTable method path
     case mstrm0 of
         Just strm0 -> do
             deleteEvenCache evenStreamTable method path
-            return strm0
+            return (strm0, Nothing)
         Nothing -> do
             -- Arch/Sender is originally implemented for servers where
             -- the ordering of responses can be out-of-order.
@@ -200,38 +205,41 @@ sendRequest conf ctx@Context{..} scheme auth (Request req) = do
                     | otherwise = hdr1
                 req' = req{outObjHeaders = hdr2}
             -- FLOW CONTROL: SETTINGS_MAX_CONCURRENT_STREAMS: send: respecting peer's limit
-            (sid, newstrm) <- openOddStreamWait ctx
-            sendHeaderBody conf ctx sid newstrm req'
-            return newstrm
+            (_sid, newstrm) <- openOddStreamWait ctx
+            return (newstrm, Just req')
 
-sendHeaderBody :: Config -> Context -> StreamId -> Stream -> OutObj -> IO ()
-sendHeaderBody Config{..} ctx@Context{..} sid newstrm OutObj{..} = do
-    (mnext, mtbq) <- case outObjBody of
-        OutBodyNone -> return (Nothing, Nothing)
-        OutBodyFile (FileSpec path fileoff bytecount) -> do
-            (pread, sentinel) <- confPositionReadMaker path
-            let next = fillFileBodyGetNext pread fileoff bytecount sentinel
-            return (Just next, Nothing)
-        OutBodyBuilder builder -> do
-            let next = fillBuilderBodyGetNext builder
-            return (Just next, Nothing)
-        OutBodyStreaming strmbdy -> do
-            q <- sendStreaming ctx newstrm $ \iface ->
-                outBodyUnmask iface $ strmbdy (outBodyPush iface) (outBodyFlush iface)
-            let next = nextForStreaming q
-            return (Just next, Just q)
-        OutBodyStreamingIface strmbdy -> do
-            q <- sendStreaming ctx newstrm strmbdy
-            let next = nextForStreaming q
-            return (Just next, Just q)
-    ((var, sync), out) <-
-        prepareSync newstrm (OHeader outObjHeaders mnext outObjTrailers) mtbq
-    atomically $ do
-        sidOK <- readTVar outputQStreamID
-        check (sidOK == sid)
-        enqueueOutputSTM outputQ out
-        writeTVar outputQStreamID (sid + 2)
-    forkManaged threadManager "H2 worker" $ syncWithSender ctx newstrm var sync
+sendRequest :: Config -> Context -> Stream -> OutObj -> IO ()
+sendRequest Config{..} ctx@Context{..} strm OutObj{..} =
+    forkManaged threadManager label $ do
+        let sid = streamNumber strm
+        (mnext, mtbq) <- case outObjBody of
+            OutBodyNone -> return (Nothing, Nothing)
+            OutBodyFile (FileSpec path fileoff bytecount) -> do
+                (pread, sentinel) <- confPositionReadMaker path
+                let next = fillFileBodyGetNext pread fileoff bytecount sentinel
+                return (Just next, Nothing)
+            OutBodyBuilder builder -> do
+                let next = fillBuilderBodyGetNext builder
+                return (Just next, Nothing)
+            OutBodyStreaming strmbdy -> do
+                q <- sendStreaming ctx strm $ \iface ->
+                    outBodyUnmask iface $ strmbdy (outBodyPush iface) (outBodyFlush iface)
+                let next = nextForStreaming q
+                return (Just next, Just q)
+            OutBodyStreamingIface strmbdy -> do
+                q <- sendStreaming ctx strm strmbdy
+                let next = nextForStreaming q
+                return (Just next, Just q)
+        ((var, sync), out) <-
+            prepareSync strm (OHeader outObjHeaders mnext outObjTrailers) mtbq
+        atomically $ do
+            sidOK <- readTVar outputQStreamID
+            check (sidOK == sid)
+            enqueueOutputSTM outputQ out
+            writeTVar outputQStreamID (sid + 2)
+        syncWithSender ctx strm var sync
+  where
+    label = "H2 request sender for stream " ++ show (streamNumber strm)
 
 sendStreaming
     :: Context

--- a/Network/HTTP2/H2/Sync.hs
+++ b/Network/HTTP2/H2/Sync.hs
@@ -1,99 +1,92 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Network.HTTP2.H2.Sync (prepareSync, syncWithSender) where
+module Network.HTTP2.H2.Sync (
+    LoopCheck (..),
+    newLoopCheck,
+    syncWithSender,
+    syncWithSender',
+    makeOutput,
+) where
 
 import Control.Concurrent
 import Control.Concurrent.STM
+import Control.Monad
+import Network.Control
 import Network.HTTP.Semantics.IO
 
 import Network.HTTP2.H2.Context
 import Network.HTTP2.H2.Queue
 import Network.HTTP2.H2.Types
-import Network.HTTP2.H2.Window
-
--- | Two assumptions about how this function is used:
---
--- 1. A separate thread will be running 'syncWithSender' using the @var@ and
---    @sync@ values constructed here.
--- 2. The 'Output' will be enqueued in the 'outputQ' of some 'Context'
---
--- The returned @sync@ function then has the following usage constraints:
---
--- 1. It may only be called with a 'Just' 'OutputType' if there is no 'Output'
---    already enqueued in the 'outputQ' for the given stream.
--- 2. If the function returns 'False', no other 'Output' may be enqueued for
---    this stream (until one has been dequeued).
-prepareSync
-    :: Stream
-    -> OutputType
-    -> Maybe (TBQueue StreamingChunk)
-    -> IO ((MVar Sync, Maybe OutputType -> IO Bool), Output)
-prepareSync strm otyp mtbq = do
-    var <- newEmptyMVar
-    let sync = makeSync strm mtbq var
-        out = Output strm otyp sync
-    return ((var, sync), out)
 
 syncWithSender
     :: Context
     -> Stream
-    -> MVar Sync
-    -- ^ Precondition: When this is filled with an 'Output' for a particular
-    -- stream, the 'outputQ' in the 'Context' /must not/ already contain an
-    -- 'Output' for that stream.
-    -> (Maybe OutputType -> IO Bool)
+    -> OutputType
+    -> LoopCheck
     -> IO ()
-syncWithSender Context{..} strm var sync = loop
+syncWithSender ctx@Context{..} strm otyp lc = do
+    (var, out) <- makeOutput strm otyp
+    enqueueOutput outputQ out
+    syncWithSender' ctx var lc
+
+makeOutput :: Stream -> OutputType -> IO (MVar Sync, Output)
+makeOutput strm otyp = do
+    var <- newEmptyMVar
+    let out =
+            Output
+                { outputStream = strm
+                , outputType = otyp
+                , outputSync = putMVar var
+                }
+    return (var, out)
+
+syncWithSender' :: Context -> MVar Sync -> LoopCheck -> IO ()
+syncWithSender' Context{..} var lc = loop
   where
     loop = do
         s <- takeMVar var
         case s of
             Done -> return ()
-            Cont wait newotyp -> do
-                wait
-                -- This is justified by the precondition above
-                enqueueOutput outputQ $ Output strm newotyp sync
-                loop
+            Cont newout -> do
+                cont <- checkLoop lc
+                when cont $ do
+                    -- This is justified by the precondition above
+                    enqueueOutput outputQ newout
+                    loop
 
--- | Postcondition: This will only write to the 'MVar' if:
---
--- 1. You pass 'Just' an 'OutputType'
--- 2. The return value is 'False'
-makeSync
-    :: Stream
-    -> Maybe (TBQueue StreamingChunk)
-    -> MVar Sync
-    -> Maybe OutputType
-    -> IO Bool
-makeSync _ _ var Nothing = putMVar var Done >> return False
-makeSync strm mtbq var (Just otyp) = do
-    mwait <- checkOpen strm mtbq
-    case mwait of
-        Nothing -> return True
-        Just wait -> do
-            putMVar var $ Cont wait otyp
-            return False
+newLoopCheck :: Stream -> Maybe (TBQueue StreamingChunk) -> IO LoopCheck
+newLoopCheck strm mtbq = do
+    tovar <- newTVarIO False
+    return $
+        LoopCheck
+            { lcTBQ = mtbq
+            , lcTimeout = tovar
+            , lcWindow = streamTxFlow strm
+            }
 
-checkOpen :: Stream -> Maybe (TBQueue StreamingChunk) -> IO (Maybe (IO ()))
-checkOpen strm mtbq = case mtbq of
-    Nothing -> checkStreamWindowSize
-    Just tbq -> checkStreaming tbq
-  where
-    checkStreaming tbq = do
-        isEmpty <- atomically $ isEmptyTBQueue tbq
-        if isEmpty
-            then do
-                return $ Just (waitStreaming tbq)
-            else checkStreamWindowSize
-    -- FLOW CONTROL: WINDOW_UPDATE: send: respecting peer's limit
-    checkStreamWindowSize = do
-        sws <- getStreamWindowSize strm
-        if sws <= 0
-            then return $ Just (waitStreamWindowSize strm)
-            else return Nothing
+data LoopCheck = LoopCheck
+    { lcTBQ :: Maybe (TBQueue StreamingChunk)
+    , lcTimeout :: TVar Bool
+    , lcWindow :: TVar TxFlow
+    }
 
-{-# INLINE waitStreaming #-}
-waitStreaming :: TBQueue a -> IO ()
-waitStreaming tbq = atomically $ do
+checkLoop :: LoopCheck -> IO Bool
+checkLoop LoopCheck{..} = atomically $ do
+    tout <- readTVar lcTimeout
+    if tout
+        then return False
+        else do
+            waitStreaming' lcTBQ
+            waitStreamWindowSizeSTM lcWindow
+            return True
+
+waitStreaming' :: Maybe (TBQueue a) -> STM ()
+waitStreaming' Nothing = return ()
+waitStreaming' (Just tbq) = do
     isEmpty <- isEmptyTBQueue tbq
     check (not isEmpty)
+
+waitStreamWindowSizeSTM :: TVar TxFlow -> STM ()
+waitStreamWindowSizeSTM txf = do
+    w <- txWindowSize <$> readTVar txf
+    check (w > 0)

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -179,7 +179,7 @@ instance Show Stream where
 data Output = Output
     { outputStream :: Stream
     , outputType :: OutputType
-    , outputSync :: Maybe OutputType -> IO Bool
+    , outputSync :: Sync -> IO ()
     }
 
 data OutputType
@@ -187,7 +187,7 @@ data OutputType
     | OPush TokenHeaderList StreamId -- associated stream id from client
     | ONext DynaNext TrailersMaker
 
-data Sync = Done | Cont (IO ()) OutputType
+data Sync = Done | Cont Output
 
 ----------------------------------------------------------------
 

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -49,10 +49,7 @@ run :: ServerConfig -> Config -> Server -> IO ()
 run sconf conf server = do
     ok <- checkPreface conf
     when ok $ do
-        let lnch ctx strm inpObj = do
-                let label = "H2 worker for stream " ++ show (streamNumber strm)
-                forkManaged (threadManager ctx) label $
-                    worker conf server ctx strm inpObj
+        let lnch = runServer conf server
         ctx <- setup sconf conf lnch
         runH2 conf ctx
 

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -84,9 +84,9 @@ runIO sconf conf@Config{..} action = do
                 case outObjBody of
                     OutBodyBuilder builder -> do
                         let next = fillBuilderBodyGetNext builder
-                            sync _ = return True
-                            out = OHeader outObjHeaders (Just next) outObjTrailers
-                        enqueueOutput outputQ $ Output strm out sync
+                            otyp = OHeader outObjHeaders (Just next) outObjTrailers
+                        (_, out) <- makeOutput strm otyp
+                        enqueueOutput outputQ out
                     _ -> error "Response other than OutBodyBuilder is not supported"
             serverIO =
                 ServerIO

--- a/Network/HTTP2/Server/Worker.hs
+++ b/Network/HTTP2/Server/Worker.hs
@@ -22,7 +22,7 @@ import Network.HTTP2.H2
 runServer :: Config -> Server -> Context -> Stream -> InpObj -> IO ()
 runServer conf server ctx@Context{..} strm req =
     forkManaged threadManager label $
-        timeoutKillThread threadManager $ \th -> do
+        withTimeout threadManager $ \th -> do
             -- FIXME: exception
             T.pause th
             let req' = pauseRequestBody th
@@ -84,7 +84,7 @@ pushStream conf ctx@Context{..} pstrm reqvt pps0
     push _ [] n = return (n :: Int)
     push tvar (pp : pps) n = do
         forkManaged threadManager "H2 server push" $ do
-            timeoutKillThread threadManager $ \th -> do
+            withTimeout threadManager $ \th -> do
                 (pid, newstrm) <- makePushStream ctx pstrm
                 let scheme = fromJust $ getFieldValue tokenScheme reqvt
                     -- fixme: this value can be Nothing


### PR DESCRIPTION
@edsko @FinleyMcIlwaine This PR simplifies the syncing way between workers and the sender.
A worker must take care of window for its stream.
So, the sender need not to take care of window for streams and can concentrates on window for the connection.
You don't have to understand the code in detail.
I would like you to test this PR with your stress testings.