### PR TITLE
workaround of sync for SIO

### DIFF
--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -152,18 +152,14 @@ frameSender
                 else case otyp of
                     OHeader hdr mnext tlrmkr -> do
                         (off', mout') <- outputHeader strm hdr mnext tlrmkr sync off
-                        case mout' of
-                            Nothing -> sync Done
-                            Just out' -> sync $ Cont out'
+                        sync mout'
                         return off'
                     _ -> do
                         sws <- getStreamWindowSize strm
                         cws <- getConnectionWindowSize ctx -- not 0
                         let lim = min cws sws
                         (off', mout') <- output out off lim
-                        case mout' of
-                            Nothing -> sync Done
-                            Just out' -> sync $ Cont out'
+                        sync mout'
                         return off'
 
         resetStream :: Stream -> ErrorCode -> E.SomeException -> IO ()
@@ -178,7 +174,7 @@ frameSender
             -> [Header]
             -> Maybe DynaNext
             -> TrailersMaker
-            -> (Sync -> IO ())
+            -> (Maybe Output -> IO ())
             -> Offset
             -> IO (Offset, Maybe Output)
         outputHeader strm hdr mnext tlrmkr sync off0 = do

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -183,7 +183,7 @@ instance Show Stream where
 data Output = Output
     { outputStream :: Stream
     , outputType :: OutputType
-    , outputSync :: Sync -> IO ()
+    , outputSync :: Maybe Output -> IO ()
     }
 
 data OutputType

--- a/Network/HTTP2/Server/Run.hs
+++ b/Network/HTTP2/Server/Run.hs
@@ -76,7 +76,7 @@ runIO sconf conf@Config{..} action = do
     when ok $ do
         inpQ <- newTQueueIO
         let lnch _ strm inpObj = atomically $ writeTQueue inpQ (strm, inpObj)
-        ctx@Context{..} <- setup sconf conf lnch
+        ctx <- setup sconf conf lnch
         let get = do
                 (strm, inpObj) <- atomically $ readTQueue inpQ
                 return (strm, Request inpObj)
@@ -85,8 +85,7 @@ runIO sconf conf@Config{..} action = do
                     OutBodyBuilder builder -> do
                         let next = fillBuilderBodyGetNext builder
                             otyp = OHeader outObjHeaders (Just next) outObjTrailers
-                        (_, out) <- makeOutput strm otyp
-                        enqueueOutput outputQ out
+                        enqueueOutputSIO ctx strm otyp
                     _ -> error "Response other than OutBodyBuilder is not supported"
             serverIO =
                 ServerIO


### PR DESCRIPTION
@khibino For SIO, the sender enqueues output again by itself.
This means the stream TX window is completely ignored.