### PR TITLE
Improve manager

### DIFF
--- a/Network/HTTP2/H2/Manager.hs
+++ b/Network/HTTP2/H2/Manager.hs
@@ -76,6 +76,10 @@ stopAfter (Manager _timmgr var) action cleanup = do
             writeTVar var Map.empty
             return m0
         let ths = Map.elems m
+        -- Managed threads may receive 'TimeoutThread' and
+        -- 'KilledByHttp2ThreadManager'. Before throwing to
+        -- 'KilledByHttp2ThreadManager' to the tagets,
+        -- let's cancel 'TimeoutThread' to avoid race.
         forM_ (map snd ths) cancelTimeout
         let er = either Just (const Nothing) ma
         forM_ (map fst ths) $ \wtid -> do

--- a/Network/HTTP2/H2/Manager.hs
+++ b/Network/HTTP2/H2/Manager.hs
@@ -112,9 +112,9 @@ forkManagedUnmask (Manager _timmgr var) label io =
         (wtid, n) <- myWeakThradId
         -- asking to throw KilledByHttp2ThreadManager to me
         let ent = ManagedThread wtid Nothing
-        atomically $ modifyTVar var $ Map.insert n ent
+        atomically $ modifyTVar' var $ Map.insert n ent
         return n
-    clear n = atomically $ modifyTVar var $ Map.delete n
+    clear n = atomically $ modifyTVar' var $ Map.delete n
     ignore (KilledByHttp2ThreadManager _) = return ()
 
 waitCounter0 :: Manager -> IO ()
@@ -130,7 +130,7 @@ withTimeout (Manager timmgr var) action =
         (wtid, n) <- myWeakThradId
         -- overriding Nothing to Just if already exist
         let ent = ManagedThread wtid $ Just th
-        atomically $ modifyTVar var $ Map.insert n ent
+        atomically $ modifyTVar' var $ Map.insert n ent
         action th
 
 myWeakThradId :: IO (Weak ThreadId, Int)


### PR DESCRIPTION
- `forkManagedTimeout` ensures that only one asynchronous exception is thrown with a lock of `IORef Bool`. (relating to #136, #137)
- Fixing the thread leak via `Weak ThreadId` and `modifyTVar'` (relating to #154)
- `TimeoutThread` and `KilledByHttp2ThreadManager` are caught cleanly (relating to #153)