### PR TITLE
fix: restore `Config` exported constructor

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -71,7 +71,7 @@ module Network.HTTP2.Client (
     rstRateLimit,
 
     -- * Common configuration
-    Config,
+    Config (..),
     defaultConfig,
     confWriteBuffer,
     confBufferSize,

--- a/Network/HTTP2/Server.hs
+++ b/Network/HTTP2/Server.hs
@@ -51,7 +51,7 @@ module Network.HTTP2.Server (
     rstRateLimit,
 
     -- * Common configuration
-    Config,
+    Config (..),
     defaultConfig,
     confWriteBuffer,
     confBufferSize,


### PR DESCRIPTION
We have some fine grained logic which needs direct access to the constructor.