### PR TITLE
Fix regression in 5.4.0: re-introduce `CFinish`

### DIFF
--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -51,8 +51,12 @@ frameReceiver ctx conf@Config{..} =
         `E.finally` atomically
             (writeTVar (receiverDone ctx) True)
   where
-    handler ConnectionIsClosed = return ()
-    handler e = E.throwIO e
+    handler :: HTTP2Error -> IO ()
+    handler e = do
+        enqueueControl (controlQ ctx) $ CFinish e
+        case e of
+            ConnectionIsClosed -> return ()
+            _otherwise -> E.throwIO e
     switch = do
         labelMe "H2 receiver"
         tid <- myThreadId

--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -126,6 +126,7 @@ frameSender
 
         -- called with off == 0
         control :: Control -> IO ()
+        control (CFinish e) = E.throwIO e
         control (CFrames ms xs) = do
             buf <- copyAll xs confWriteBuffer
             let off = buf `minusPtr` confWriteBuffer

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -195,7 +195,9 @@ data Sync = Done | Cont Output
 
 ----------------------------------------------------------------
 
-data Control = CFrames (Maybe SettingsList) [ByteString]
+data Control
+    = CFinish HTTP2Error
+    | CFrames (Maybe SettingsList) [ByteString]
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
@kazu-yamamoto I've marked this as a draft PR, because I haven't yet tested this against the full `grapesy` test suite. I will, but already submitting it as a draft PR now to ask you for some early feedback, in case you feel that the approach in this PR is wrong.

## Detailed description

In #157 quite a few changes are made to the control flow. I don't fully understand the details, but one crucial change is that the `CFinal` constructor is deleted. This has some cascading consequences:

* When the `frameReceiver` notices that the connection is closed, it no longer notifies the `frameSender` thread, which therefore does not terminate. 
* Therefore the call to `concurrently_ runReceiver runSender` by `runBackgroundThreads` in `runH2` never terminates.
* Therefore `closeAllStreams` is never called
* Therefore any server handlers that are waiting for (streaming) client input (that is, are blocked on a call to `inpObjBody`) are blocked forever, instead of being notified that the client connection is closed.

On the client side instead of a call to `concurrently_` we have a call to `race`, so that the frame sender is terminated when the frame receiver returns. It is tempting to do the same also on the server, but https://github.com/kazu-yamamoto/http2/pull/67 very explicitly does _not_ do this; I don't fully understand the details here, and in particular do not know of the discussion in that ticket is still relevant with today's architecture. Reintroducing `CFinal`, albeit used in a more limited way than it was previously seemed the safer bet.

