### PR TITLE
Fix regression in 5.4.0: Re-throw `ConnectionIsClosed` from `frameSender`

### DIFF
--- a/Network/HTTP2/H2/Context.hs
+++ b/Network/HTTP2/H2/Context.hs
@@ -90,10 +90,15 @@ data Context = Context
     , mySockAddr         :: SockAddr
     , peerSockAddr       :: SockAddr
     , threadManager      :: T.ThreadManager
-    , receiverDone       :: TVar Bool
+    , receiverStatus     :: TVar ReceiverStatus
     , workersDone        :: STM Bool
     }
 {- FOURMOLU_ENABLE -}
+
+data ReceiverStatus
+    = ReceiverRunning
+    | ReceiverDone (Maybe SomeException)
+    | ReceiverConnectionClosed
 
 ----------------------------------------------------------------
 
@@ -138,7 +143,7 @@ newContext roleInfo Config{..} cacheSiz connRxWS mySettings timmgr mdone = do
     let mySockAddr   = confMySockAddr
     let peerSockAddr = confPeerSockAddr
     threadManager   <- T.newThreadManager timmgr
-    receiverDone    <- newTVarIO False
+    receiverStatus  <- newTVarIO ReceiverRunning
     let workersDone = fromMaybe (T.isAllGone threadManager) mdone
     return Context{..}
   where

--- a/Network/HTTP2/H2/Receiver.hs
+++ b/Network/HTTP2/H2/Receiver.hs
@@ -46,13 +46,20 @@ headerFragmentLimit = 51200 -- 50K
 ----------------------------------------------------------------
 
 frameReceiver :: Context -> Config -> IO ()
-frameReceiver ctx conf@Config{..} =
-    (switch `E.catch` handler)
-        `E.finally` atomically
-            (writeTVar (receiverDone ctx) True)
+frameReceiver ctx@Context{receiverStatus} conf@Config{..} =
+    E.mask $ \unmask -> do
+        mErr <- E.try $ unmask switch
+        case mErr of
+            Left err | Just ConnectionIsClosed <- E.fromException err -> do
+                atomically $ writeTVar receiverStatus $ ReceiverConnectionClosed
+                return ()
+            Left err -> do
+                atomically $ writeTVar receiverStatus $ ReceiverDone (Just err)
+                E.throwIO err
+            Right () -> do
+                atomically $ writeTVar receiverStatus $ ReceiverDone Nothing
+                return ()
   where
-    handler ConnectionIsClosed = return ()
-    handler e = E.throwIO e
     switch = do
         labelMe "H2 receiver"
         tid <- myThreadId

--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -67,11 +67,15 @@ checkDone Context{..} 0 = atomically $ do
         then
             return False
         else do
-            gone <- isAllGone threadManager
-            unless gone retry
-            done <- readTVar receiverDone
-            unless done retry
-            return True
+            threadMgrGone <- isAllGone threadManager
+            recvStatus <- readTVar receiverStatus
+            case (threadMgrGone, recvStatus) of
+                (_, ReceiverConnectionClosed) ->
+                    throwSTM ConnectionIsClosed
+                (True, ReceiverDone _) ->
+                    return True
+                _otherwise ->
+                    retry
 checkDone _ _ = return False
 
 frameSender :: Context -> Config -> IO ()


### PR DESCRIPTION
@kazu-yamamoto Ok, this is a new attempt at #164 . 

The `grapesy` test suite passes with this PR (as does `http2`'s own test suite). Or course, if you feel this needs further adjustment, do let me know! Once we agree on how to solve this problem, I'll be submitting one or two further PRs also.

## Deadlock

First, my analysis of the deadlock I observed in my tests. 

* Suppose we have a server currently handling a streaming request from a client, and the client abruptly disconnects.
* The `frameReceiver` will notice the disconnect, and terminate. It explicitly swallows the `ConnectionIsClosed` exception:

https://github.com/kazu-yamamoto/http2/blob/47b38d72b4c09ab8b55ac55824ae6cadbded5ab7/Network/HTTP2/H2/Receiver.hs#L54-L55

* [`checkDone`](https://github.com/kazu-yamamoto/http2/blob/47b38d72b4c09ab8b55ac55824ae6cadbded5ab7/Network/HTTP2/H2/Sender.hs#L62) in the `frameSender` will notice that the receiver has terminated ([`done`](https://github.com/kazu-yamamoto/http2/blob/47b38d72b4c09ab8b55ac55824ae6cadbded5ab7/Network/HTTP2/H2/Sender.hs#L72)), but it won't yet terminate because not all threads have terminated: not [`gone`](https://github.com/kazu-yamamoto/http2/blob/47b38d72b4c09ab8b55ac55824ae6cadbded5ab7/Network/HTTP2/H2/Sender.hs#L70).
* However (and here is the deadlock): those threads _would_ be terminated (killed, in fact) by the [call to `stopAfter` in `runH2`](https://github.com/kazu-yamamoto/http2/blob/47b38d72b4c09ab8b55ac55824ae6cadbded5ab7/Network/HTTP2/Server/Run.hs#L135). After all, the connection is closed, so any server threads that are still running are no longer relevant.

So here's the deadlock: `frameSender` is not terminating because not all server threads have terminated, but the server threads cannot terminate because they are are waiting for more input from the client and are not informed that the connection has been closed.

## Solution

I am not completely sure what the motivation is for swallowing the `ConnectionIsClosed` in `frameReceiver`, but I _guess_ it's to allow the `frameSender` to terminate cleanly. I've now generalized the `receiverDone` `TVar` to `receiverStatus` instead: when the frame receiver terminates, it records _how_: cleanly, with an exception, or because the connection is closed. Then in `frameSender` when we check the `receiverStatus`, _if_ the connection is closed we throw the `ConnectionIsClosed` exception at that point.

It is important that we throw this exception (rather than simply terminate the `frameSender`), because if we simply terminate, then to a server handler this looks like the client cleanly terminated the stream rather than got disconnected. I think this may be important within `http2` itself also; for example, `closureServer` [explicitly checks for `ConnectionIsClosed`](https://github.com/kazu-yamamoto/http2/blob/main/Network/HTTP2/H2/Receiver.hs#L656); if we don't rethrow that exception, that case would never trigger.
