### PR TITLE
Improvements for dealing with RST_STREAM

### DIFF
--- a/Network/HTTP2/Client.hs
+++ b/Network/HTTP2/Client.hs
@@ -90,6 +90,7 @@ module Network.HTTP2.Client (
 
     -- * Error
     HTTP2Error (..),
+    StreamTerminated (..),
     ReasonPhrase,
     ErrorCode (
         ErrorCode,
@@ -115,3 +116,4 @@ import Network.HTTP.Semantics.Client
 import Network.HTTP2.Client.Run
 import Network.HTTP2.Frame
 import Network.HTTP2.H2 hiding (authority, scheme)
+import Network.HTTP2.H2.OutBodyIface

--- a/Network/HTTP2/H2/Context.hs
+++ b/Network/HTTP2/H2/Context.hs
@@ -193,20 +193,24 @@ modifyPeerLastStreamId ctx sid = atomicModifyIORef' (peerLastStreamId ctx) $ \n 
 
 {-# INLINE setStreamState #-}
 setStreamState :: Context -> Stream -> StreamState -> IO ()
-setStreamState _ Stream{streamState} newState = atomically $ do
+setStreamState _ Stream{streamNumber, streamState} newState = atomically $ do
     oldState <- readTVar streamState
+
+    -- Inform consumers of any streams that we close
     case (oldState, newState) of
         (Open _ (Body q _ _ _), Open _ (Body q' _ _ _))
             | q == q' ->
                 -- The stream stays open with the same body; nothing to do
                 return ()
+        (Open _ (Body q _ _ _), Closed cc) ->
+            writeTQueue q $ Left $ E.toException $ closedCodeToError streamNumber cc
         (Open _ (Body q _ _ _), _) ->
-            -- The stream is either closed, or is open with a /new/ body
-            -- We need to close the old queue so that any reads from it won't block
+            -- The stream is opened with a /new/ body
             writeTQueue q $ Left $ E.toException ConnectionIsClosed
         _otherwise ->
             -- The stream wasn't open to start with; nothing to do
             return ()
+
     writeTVar streamState newState
 
 opened :: Context -> Stream -> IO ()

--- a/Network/HTTP2/H2/OutBodyIface.hs
+++ b/Network/HTTP2/H2/OutBodyIface.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Network.HTTP2.H2.OutBodyIface (
+    StreamTerminated (..),
     withOutBodyIface,
 ) where
 
@@ -19,6 +20,7 @@ data StreamTerminated
     = StreamPushedFinal
     | StreamCancelled
     | StreamOutOfScope
+    | StreamRemoteReset ClosedCode
     deriving (Show)
     deriving anyclass (Exception)
 
@@ -31,12 +33,39 @@ withOutBodyIface
     -> (forall a. IO a -> IO a)
     -> (OutBodyIface -> IO r)
     -> IO r
-withOutBodyIface _ctx _strm tbq unmask k = do
+withOutBodyIface _ctx strm tbq unmask k = do
     terminated <- newTVarIO Nothing
     let checkNotTerminated :: STM ()
         checkNotTerminated = do
             mTerminated <- readTVar terminated
             maybe (return ()) throwSTM mTerminated
+
+        getIsClosed :: STM (Maybe ClosedCode)
+        getIsClosed = do
+            st <- readTVar (streamState strm)
+            case st of
+                Closed code -> return $ Just code
+                _otherwise -> return Nothing
+
+        -- Check if the peer is still listening for messages
+        --
+        -- It is important to call 'checkNotClosed' prior to enqueuing stream
+        -- chunks to ensure that 'writeTBQueue' will not block indefinitely
+        -- (because nothing is consuming elements from the queue anymore).
+        --
+        -- Assumes 'checkNotTerminated'.
+        checkNotClosed :: STM ()
+        checkNotClosed = do
+            mClosed <- getIsClosed
+            case mClosed of
+                Just code ->
+                    -- When the stream is closed, but /we/ did not close it (or
+                    -- 'checkNotTerminated' would have thrown an exception), it
+                    -- must mean that our peer send us a RST_STREAM, indicating
+                    -- that they do not want to receive any further messages.
+                    throwSTM $ StreamRemoteReset code
+                _otherwise ->
+                    return ()
 
         iface :: OutBodyIface
         iface =
@@ -44,35 +73,46 @@ withOutBodyIface _ctx _strm tbq unmask k = do
                 { outBodyUnmask = unmask
                 , outBodyPush = \b -> atomically $ do
                     checkNotTerminated
+                    checkNotClosed
                     writeTBQueue tbq $ StreamingBuilder b NotEndOfStream
                 , outBodyPushFinal = \b -> atomically $ do
                     checkNotTerminated
+                    checkNotClosed
                     writeTVar terminated (Just StreamPushedFinal)
                     writeTBQueue tbq $ StreamingBuilder b (EndOfStream Nothing)
                     writeTBQueue tbq $ StreamingFinished Nothing
                 , outBodyFlush = atomically $ do
                     checkNotTerminated
+                    checkNotClosed
                     writeTBQueue tbq StreamingFlush
                 , outBodyCancel = \mErr -> atomically $ do
                     mTerminated <- readTVar terminated
-                    case mTerminated of
-                        Nothing -> do
+                    mClosed <- getIsClosed
+                    case (mClosed, mTerminated) of
+                        (Nothing, Nothing) -> do
                             writeTVar terminated (Just StreamCancelled)
                             writeTBQueue tbq $ StreamingCancelled mErr
-                        Just _ ->
-                            -- Already terminated
+                        (Nothing, Just _) ->
+                            -- We already terminated
+                            return ()
+                        (Just _code, _) ->
+                            -- Peer already closed
                             return ()
                 }
 
         finished :: IO ()
         finished = atomically $ do
             mTerminated <- readTVar terminated
-            case mTerminated of
-                Nothing -> do
+            mClosed <- getIsClosed
+            case (mClosed, mTerminated) of
+                (Nothing, Nothing) -> do
                     writeTVar terminated (Just StreamOutOfScope)
                     writeTBQueue tbq $ StreamingFinished Nothing
-                Just _ ->
-                    -- Already terminated
+                (Nothing, Just _) ->
+                    -- We already terminated
+                    return ()
+                (Just _code, _) ->
+                    -- Peer already closed
                     return ()
 
     k iface `finally` finished

--- a/Network/HTTP2/H2/OutBodyIface.hs
+++ b/Network/HTTP2/H2/OutBodyIface.hs
@@ -42,13 +42,6 @@ withOutBodyIface ctx@Context{outputQ} strm tbq unmask k = do
             mTerminated <- readTVar terminated
             maybe (return ()) throwSTM mTerminated
 
-        getIsClosed :: STM (Maybe ClosedCode)
-        getIsClosed = do
-            st <- readTVar (streamState strm)
-            case st of
-                Closed code -> return $ Just code
-                _otherwise -> return Nothing
-
         -- Check if the peer is still listening for messages
         --
         -- It is important to call 'checkNotClosed' prior to enqueuing stream
@@ -68,6 +61,13 @@ withOutBodyIface ctx@Context{outputQ} strm tbq unmask k = do
                     throwSTM $ StreamRemoteReset code
                 _otherwise ->
                     return ()
+
+        getIsClosed :: STM (Maybe ClosedCode)
+        getIsClosed = do
+            st <- readTVar (streamState strm)
+            case st of
+                Closed code -> return $ Just code
+                _otherwise -> return Nothing
 
         cancelAfterFinish :: Maybe SomeException -> STM ()
         cancelAfterFinish mErr =

--- a/Network/HTTP2/H2/OutBodyIface.hs
+++ b/Network/HTTP2/H2/OutBodyIface.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Network.HTTP2.H2.OutBodyIface (
@@ -12,6 +13,7 @@ import Control.Exception
 import Network.HTTP.Semantics
 import Network.HTTP.Semantics.IO
 import Network.HTTP2.H2.Context
+import Network.HTTP2.H2.Sync
 import Network.HTTP2.H2.Types
 
 ----------------------------------------------------------------
@@ -33,7 +35,7 @@ withOutBodyIface
     -> (forall a. IO a -> IO a)
     -> (OutBodyIface -> IO r)
     -> IO r
-withOutBodyIface _ctx strm tbq unmask k = do
+withOutBodyIface ctx@Context{outputQ} strm tbq unmask k = do
     terminated <- newTVarIO Nothing
     let checkNotTerminated :: STM ()
         checkNotTerminated = do
@@ -67,6 +69,10 @@ withOutBodyIface _ctx strm tbq unmask k = do
                 _otherwise ->
                     return ()
 
+        cancelAfterFinish :: Maybe SomeException -> STM ()
+        cancelAfterFinish mErr =
+            writeTQueue outputQ $ makeOutputIO ctx strm (OReset mErr)
+
         iface :: OutBodyIface
         iface =
             OutBodyIface
@@ -92,9 +98,15 @@ withOutBodyIface _ctx strm tbq unmask k = do
                         (Nothing, Nothing) -> do
                             writeTVar terminated (Just StreamCancelled)
                             writeTBQueue tbq $ StreamingCancelled mErr
-                        (Nothing, Just _) ->
-                            -- We already terminated
+                        (Nothing, Just StreamCancelled) ->
+                            -- Already cancelled
                             return ()
+                        (Nothing, Just _) -> do
+                            -- We finished streaming (that is, sending messages to the peer),
+                            -- but we must still be able to cancel the stream entirely
+                            -- (that is, tell the peer that we no longer want to /receive/ messages: RST_STREAM)
+                            writeTVar terminated (Just StreamCancelled)
+                            cancelAfterFinish mErr
                         (Just _code, _) ->
                             -- Peer already closed
                             return ()

--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -162,7 +162,13 @@ frameSender
         outputAndSync out@(Output strm otyp sync) off = E.handle (\e -> resetStream strm InternalError e >> return off) $ do
             state <- readStreamState strm
             if isHalfClosedLocal state
-                then return off
+                then case otyp of
+                    OReset mErr | not (isClosed state) -> do
+                        -- RST_STREAM is the only frame we can still send after half-closing
+                        resetStreamWith strm mErr
+                        return off
+                    _otherwise ->
+                        return off
                 else case otyp of
                     OHeader hdr mnext tlrmkr -> do
                         (off', mout') <- outputHeader strm hdr mnext tlrmkr sync off

--- a/Network/HTTP2/H2/Sync.hs
+++ b/Network/HTTP2/H2/Sync.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.HTTP2.H2.Sync (
@@ -101,12 +102,10 @@ checkLoop :: LoopCheck -> IO Bool
 checkLoop LoopCheck{..} = atomically $ do
     tout <- readTVar lcTimeout
     state <- readTVar lcState
-    case (tout, state) of
-        (True, _) ->
-            return False
-        (_, Closed{}) ->
-            return False
-        _otherwise -> do
+    if
+        | tout -> return False
+        | Closed{} <- state -> return False
+        | otherwise -> do
             waitStreaming' lcTBQ
             waitStreamWindowSizeSTM lcWindow
             return True

--- a/Network/HTTP2/H2/Sync.hs
+++ b/Network/HTTP2/H2/Sync.hs
@@ -76,7 +76,6 @@ syncWithSender' Context{..} pop lc = loop
             Cont newout -> do
                 cont <- checkLoop lc
                 when cont $ do
-                    -- This is justified by the precondition above
                     enqueueOutput outputQ newout
                     loop
 
@@ -85,13 +84,15 @@ newLoopCheck strm mtbq = do
     tovar <- newTVarIO False
     return $
         LoopCheck
-            { lcTBQ = mtbq
+            { lcState = streamState strm
+            , lcTBQ = mtbq
             , lcTimeout = tovar
             , lcWindow = streamTxFlow strm
             }
 
 data LoopCheck = LoopCheck
-    { lcTBQ :: Maybe (TBQueue StreamingChunk)
+    { lcState :: TVar StreamState
+    , lcTBQ :: Maybe (TBQueue StreamingChunk)
     , lcTimeout :: TVar Bool
     , lcWindow :: TVar TxFlow
     }
@@ -99,9 +100,13 @@ data LoopCheck = LoopCheck
 checkLoop :: LoopCheck -> IO Bool
 checkLoop LoopCheck{..} = atomically $ do
     tout <- readTVar lcTimeout
-    if tout
-        then return False
-        else do
+    state <- readTVar lcState
+    case (tout, state) of
+        (True, _) ->
+            return False
+        (_, Closed{}) ->
+            return False
+        _otherwise -> do
             waitStreaming' lcTBQ
             waitStreamWindowSizeSTM lcWindow
             return True

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -186,6 +186,7 @@ data OutputType
     | OPush TokenHeaderList StreamId -- associated stream id from client
     | ONext DynaNext TrailersMaker
     | OInformational [Header]
+    | OReset (Maybe SomeException)
 
 data Sync = Done | Cont Output
 

--- a/Network/HTTP2/H2/Types.hs
+++ b/Network/HTTP2/H2/Types.hs
@@ -132,7 +132,7 @@ closedCodeToError sid cc =
     case cc of
         Finished -> ConnectionIsClosed
         Killed -> ConnectionIsTimeout
-        Reset err -> ConnectionErrorIsReceived err sid "Connection was reset"
+        Reset err -> StreamResetIsReceived err sid
         ResetByMe err -> BadThingHappen err
 
 ----------------------------------------------------------------
@@ -186,7 +186,7 @@ data OutputType
     | OPush TokenHeaderList StreamId -- associated stream id from client
     | ONext DynaNext TrailersMaker
     | OInformational [Header]
-    | OReset (Maybe SomeException)
+    | OReset (Maybe E.SomeException)
 
 data Sync = Done | Cont Output
 
@@ -210,6 +210,7 @@ data HTTP2Error
     | ConnectionErrorIsReceived ErrorCode StreamId ReasonPhrase
     | ConnectionErrorIsSent ErrorCode StreamId ReasonPhrase
     | StreamErrorIsReceived ErrorCode StreamId
+    | StreamResetIsReceived ErrorCode StreamId
     | StreamErrorIsSent ErrorCode StreamId ReasonPhrase
     | BadThingHappen E.SomeException
     deriving (Show)


### PR DESCRIPTION
Hi @kazu-yamamoto ,

This is a series of commits, each of which fixes a different aspect of `RST_STREAM` ; I've tried to document each commit separately, let me know if anything is unclear. Two things I'd particularly like your eye on, both to do with `H2.Sync`:

* I modified `checkLoop` to check that the stream is still open, preventing a wait for a window update that will never come. This _might_ be a regression (#107)
* For `cancelAfterFinish`, I'm using `makeOutputIO`, which does no actual syncing; I think this is fine, since it's only sending a `RST_STREAM`, which is not subject to window size restrictions anyway, but I wasn't 100% sure.

I ran the full grapesy test suite and gRPC interop tests against this patch; everything green my side.

Heads up: we _may_ also have found a HPACK bug which can happen when `RST_STREAM` is received, but I'm not entirely sure yet. I don't have a reproducer yet; it's anyway unrelated to _this_ PR.